### PR TITLE
Add installation scripts for Pipedrive CLI

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,297 @@
+# Pipedrive CLI Installer for Windows
+#
+# Usage:
+#   iwr -useb https://raw.githubusercontent.com/stannardlabs/pipedrive-cli/dev/install.ps1 | iex
+#
+# Or download and run:
+#   .\install.ps1
+#   .\install.ps1 -InstallDir "C:\custom\path"
+#
+
+param(
+    [string]$InstallDir = "",
+    [switch]$Force,
+    [switch]$DryRun,
+    [switch]$Beta,
+    [switch]$Help
+)
+
+$ErrorActionPreference = "Stop"
+
+# Show help if requested
+if ($Help) {
+    Write-Host "Pipedrive CLI Installer for Windows"
+    Write-Host ""
+    Write-Host "Usage: .\install.ps1 [OPTIONS]"
+    Write-Host ""
+    Write-Host "Options:"
+    Write-Host "  -InstallDir <path>  Custom installation directory"
+    Write-Host "  -Force              Skip confirmation prompts"
+    Write-Host "  -DryRun             Download and verify but don't install"
+    Write-Host "  -Beta               Include beta/pre-release versions"
+    Write-Host "  -Help               Show this help message"
+    Write-Host ""
+    Write-Host "Examples:"
+    Write-Host "  .\install.ps1"
+    Write-Host "  .\install.ps1 -DryRun"
+    Write-Host "  .\install.ps1 -Beta -Force"
+    Write-Host "  .\install.ps1 -InstallDir 'C:\tools\pipedrive'"
+    exit 0
+}
+
+# Configuration
+$RepoOwner = "stannardlabs"
+$RepoName = "pipedrive-cli"
+$BinaryName = "pipedrive.exe"
+
+# Set default install directory if not provided
+if ([string]::IsNullOrEmpty($InstallDir)) {
+    $InstallDir = "$env:LOCALAPPDATA\Programs\pipedrive"
+}
+
+# Helper functions
+function Write-Info { Write-Host "[INFO] $args" -ForegroundColor Green }
+function Write-Warn { Write-Host "[WARN] $args" -ForegroundColor Yellow }
+function Write-Error { Write-Host "[ERROR] $args" -ForegroundColor Red; exit 1 }
+
+function Get-Platform {
+    $arch = if ([Environment]::Is64BitOperatingSystem) { "x64" } else { "x86" }
+    return "win-$arch"
+}
+
+function Get-LatestVersion {
+    param([bool]$IncludeBeta = $false)
+
+    if ($IncludeBeta) {
+        Write-Info "Fetching latest release information (including pre-releases)..."
+        $apiUrl = "https://api.github.com/repos/$RepoOwner/$RepoName/releases"
+    } else {
+        Write-Info "Fetching latest stable release information..."
+        $apiUrl = "https://api.github.com/repos/$RepoOwner/$RepoName/releases/latest"
+    }
+
+    try {
+        $headers = @{
+            "User-Agent" = "pipedrive-cli-installer"
+        }
+
+        $releases = Invoke-RestMethod -Uri $apiUrl -Headers $headers
+
+        if ($IncludeBeta -and $releases -is [array]) {
+            # Get the first release (most recent)
+            return $releases[0].tag_name
+        } else {
+            # For stable releases or single release response
+            if ($releases -is [array]) {
+                # Find first non-prerelease
+                $stable = $releases | Where-Object { -not $_.prerelease } | Select-Object -First 1
+                return $stable.tag_name
+            } else {
+                return $releases.tag_name
+            }
+        }
+    }
+    catch {
+        Write-Error "Failed to fetch release information: $_"
+    }
+}
+
+function Install-Binary {
+    param(
+        [string]$Version,
+        [string]$Platform,
+        [bool]$DryRun = $false
+    )
+
+    # Support versioned artifact names (e.g., pipedrive-1.0.0-win-x64.zip)
+    # The version tag itself doesn't have 'v' prefix, so use it directly
+    $downloadUrl = "https://github.com/$RepoOwner/$RepoName/releases/download/$Version/pipedrive-$Version-$Platform.zip"
+    $tempFile = "$env:TEMP\pipedrive-$Version.zip"
+    $tempDir = "$env:TEMP\pipedrive-$Version"
+
+    Write-Info "Downloading pipedrive $Version for $Platform..."
+
+    try {
+        # Download with progress
+        $ProgressPreference = 'Continue'
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $tempFile -UseBasicParsing
+    }
+    catch {
+        Write-Error "Failed to download from: $downloadUrl`n$_"
+    }
+
+    Write-Info "Extracting binary..."
+
+    # Create temp extraction directory
+    if (Test-Path $tempDir) {
+        Remove-Item $tempDir -Recurse -Force
+    }
+    New-Item -ItemType Directory -Path $tempDir | Out-Null
+
+    try {
+        # Extract archive
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($tempFile, $tempDir)
+    }
+    catch {
+        Write-Error "Failed to extract archive: $_"
+    }
+
+    # Find the binary
+    $binaryPath = Get-ChildItem -Path $tempDir -Filter $BinaryName -Recurse | Select-Object -First 1
+
+    if (-not $binaryPath) {
+        Write-Error "Binary not found in archive"
+    }
+
+    # Check if this is a dry run
+    if ($DryRun) {
+        Write-Info "DRY-RUN: Would install binary to $InstallDir\$BinaryName"
+        Write-Info "DRY-RUN: Binary found at: $($binaryPath.FullName)"
+
+        # Test the binary
+        try {
+            $testOutput = & $binaryPath.FullName --version 2>$null
+            if ($testOutput) {
+                Write-Info "DRY-RUN: Binary test successful: $testOutput"
+            } else {
+                Write-Warn "DRY-RUN: Binary test - no version output received"
+            }
+        }
+        catch {
+            Write-Warn "DRY-RUN: Binary test failed - may not be compatible with this system"
+        }
+
+        # Cleanup
+        Remove-Item $tempFile -Force -ErrorAction SilentlyContinue
+        Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+        return
+    }
+
+    # Create install directory if it doesn't exist
+    if (-not (Test-Path $InstallDir)) {
+        Write-Info "Creating installation directory..."
+        New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    }
+
+    # Install the binary
+    Write-Info "Installing to $InstallDir\$BinaryName..."
+    Move-Item -Path $binaryPath.FullName -Destination "$InstallDir\$BinaryName" -Force
+
+    # Cleanup
+    Remove-Item $tempFile -Force -ErrorAction SilentlyContinue
+    Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+function Add-ToPath {
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+
+    if ($userPath -notlike "*$InstallDir*") {
+        Write-Info "Adding installation directory to PATH..."
+
+        $newPath = if ($userPath -eq $null -or $userPath -eq "") {
+            $InstallDir
+        } else {
+            "$userPath;$InstallDir"
+        }
+
+        [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+
+        # Update current session
+        $env:Path = "$env:Path;$InstallDir"
+
+        Write-Warn "PATH updated. You may need to restart your terminal for changes to take effect."
+    }
+}
+
+function Test-Admin {
+    $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+    return $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+# Main installation flow
+function Main {
+    Write-Host "===================================" -ForegroundColor Cyan
+    Write-Host "  Pipedrive CLI Installer" -ForegroundColor Cyan
+    Write-Host "===================================" -ForegroundColor Cyan
+    Write-Host ""
+
+    if ($DryRun) {
+        Write-Warn "Running in DRY-RUN mode - will download but not install"
+        Write-Host ""
+    }
+
+    # Detect platform
+    $platform = Get-Platform
+    Write-Info "Detected platform: $platform"
+
+    # Get latest version
+    $version = Get-LatestVersion -IncludeBeta:$Beta
+    Write-Info "Latest version: $version"
+
+    # Check if already installed
+    $existingBinary = "$InstallDir\$BinaryName"
+    if (Test-Path $existingBinary) {
+        try {
+            $currentVersion = & $existingBinary --version 2>$null | Select-String -Pattern '\d+\.\d+\.\d+' | ForEach-Object { $_.Matches[0].Value }
+        } catch {
+            $currentVersion = "unknown"
+        }
+
+        Write-Warn "Existing installation found (version: $currentVersion)"
+
+        if (-not $Force) {
+            $response = Read-Host "Do you want to overwrite it? [y/N]"
+            if ($response -ne 'y' -and $response -ne 'Y') {
+                Write-Host "Installation cancelled"
+                exit 0
+            }
+        }
+    }
+
+    # Install binary
+    Install-Binary -Version $version -Platform $platform -DryRun:$DryRun
+
+    if ($DryRun) {
+        Write-Host ""
+        Write-Info "DRY-RUN complete! No changes were made to your system."
+        Write-Info "To actually install, run without -DryRun flag"
+    } else {
+        # Verify installation
+        try {
+            $testOutput = & "$InstallDir\$BinaryName" --version 2>$null
+            if ($testOutput) {
+                Write-Info "✓ Successfully installed pipedrive $version"
+            } else {
+                throw "Verification failed"
+            }
+        }
+        catch {
+            Write-Error "Installation verification failed: $_"
+        }
+
+        # Add to PATH
+        Add-ToPath
+
+        Write-Host ""
+        Write-Host "Installation complete! 🎉" -ForegroundColor Green
+        Write-Host ""
+        Write-Host "Run 'pipedrive --help' to get started" -ForegroundColor Cyan
+        Write-Host "Run 'pipedrive config set-api-token <token>' to configure" -ForegroundColor Cyan
+
+        # Create desktop shortcut option
+        $createShortcut = Read-Host "`nCreate desktop shortcut? [y/N]"
+        if ($createShortcut -eq 'y' -or $createShortcut -eq 'Y') {
+            $WshShell = New-Object -comObject WScript.Shell
+            $Shortcut = $WshShell.CreateShortcut("$env:USERPROFILE\Desktop\Pipedrive CLI.lnk")
+            $Shortcut.TargetPath = "$InstallDir\$BinaryName"
+            $Shortcut.WorkingDirectory = $InstallDir
+            $Shortcut.IconLocation = "$InstallDir\$BinaryName"
+            $Shortcut.Save()
+            Write-Info "Desktop shortcut created"
+        }
+    }
+}
+
+# Run main function
+Main

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+#
+# Pipedrive CLI Installer
+#
+# Usage:
+#   curl -sSL https://raw.githubusercontent.com/stannardlabs/pipedrive-cli/dev/install.sh | bash
+#   wget -qO- https://raw.githubusercontent.com/stannardlabs/pipedrive-cli/dev/install.sh | bash
+#
+# Or download and run:
+#   ./install.sh
+#   ./install.sh --dry-run
+#   INSTALL_DIR=/custom/path ./install.sh
+#
+
+set -e
+
+# Configuration
+REPO_OWNER="stannardlabs"
+REPO_NAME="pipedrive-cli"
+BINARY_NAME="pipedrive"
+INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Helper functions
+info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+error() { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
+
+# Detect OS and Architecture
+detect_platform() {
+    local os arch
+
+    # Detect OS
+    case "$(uname -s)" in
+        Linux*)  os="linux" ;;
+        Darwin*) os="osx" ;;
+        MINGW*|MSYS*|CYGWIN*)
+            error "Please use install.ps1 for Windows" ;;
+        *)
+            error "Unsupported OS: $(uname -s)" ;;
+    esac
+
+    # Detect Architecture
+    case "$(uname -m)" in
+        x86_64|amd64) arch="x64" ;;
+        aarch64|arm64) arch="arm64" ;;
+        armv7l) arch="arm" ;;
+        *) error "Unsupported architecture: $(uname -m)" ;;
+    esac
+
+    echo "${os}-${arch}"
+}
+
+# Check for required tools
+check_requirements() {
+    local missing_tools=()
+
+    command -v curl >/dev/null 2>&1 || missing_tools+=("curl")
+    command -v tar >/dev/null 2>&1 || missing_tools+=("tar")
+
+    if [ ${#missing_tools[@]} -ne 0 ]; then
+        error "Missing required tools: ${missing_tools[*]}\nPlease install them and try again."
+    fi
+}
+
+# Get latest release version from GitHub
+get_latest_version() {
+    local include_prerelease="${1:-false}"
+    local api_url
+
+    if [ "$include_prerelease" = true ]; then
+        # Get all releases and find the latest (including pre-releases)
+        api_url="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
+    else
+        # Get only the latest stable release
+        api_url="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest"
+    fi
+
+    local response
+    response=$(curl -s "$api_url") || error "Failed to fetch release information"
+
+    # Extract version from tag_name
+    local version
+    if [ "$include_prerelease" = true ]; then
+        # Get the first release from the array (most recent)
+        version=$(echo "$response" | grep '"tag_name"' | head -1 | sed -E 's/.*"tag_name":\s*"([^"]+)".*/\1/')
+    else
+        version=$(echo "$response" | grep '"tag_name"' | head -1 | sed -E 's/.*"tag_name":\s*"([^"]+)".*/\1/')
+    fi
+
+    if [ -z "$version" ]; then
+        error "Could not determine latest version"
+    fi
+
+    echo "$version"
+}
+
+# Download and install binary
+install_binary() {
+    local version="$1"
+    local platform="$2"
+
+    # Support both versioned and non-versioned artifact names
+    # Try versioned name first (e.g., pipedrive-1.0.0-linux-x64.tar.gz)
+    # The version tag itself doesn't have 'v' prefix, so use it directly
+    local download_url="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${version}/${BINARY_NAME}-${version}-${platform}.tar.gz"
+    local temp_dir
+    temp_dir=$(mktemp -d)
+    local temp_file="${temp_dir}/${BINARY_NAME}.tar.gz"
+
+    info "Downloading ${BINARY_NAME} ${version} for ${platform}..."
+
+    # Download with progress bar
+    if ! curl -L --progress-bar -o "$temp_file" "$download_url"; then
+        rm -rf "$temp_dir"
+        error "Failed to download from: $download_url"
+    fi
+
+    info "Extracting binary..."
+    if ! tar -xzf "$temp_file" -C "$temp_dir"; then
+        rm -rf "$temp_dir"
+        error "Failed to extract archive"
+    fi
+
+    # Find the binary (it might be in a subdirectory)
+    local binary_path
+    binary_path=$(find "$temp_dir" -name "$BINARY_NAME" -type f | head -1)
+
+    if [ -z "$binary_path" ]; then
+        rm -rf "$temp_dir"
+        error "Binary not found in archive"
+    fi
+
+    # Check if this is a dry run
+    if [ "$3" = true ]; then
+        info "DRY-RUN: Would install binary to ${INSTALL_DIR}/${BINARY_NAME}"
+        info "DRY-RUN: Binary found at: $binary_path"
+
+        # Test the binary
+        if "$binary_path" --version >/dev/null 2>&1; then
+            local test_version=$("$binary_path" --version 2>/dev/null | head -1)
+            info "DRY-RUN: Binary test successful: $test_version"
+        else
+            warn "DRY-RUN: Binary test failed - may not be compatible with this system"
+        fi
+
+        # Cleanup
+        rm -rf "$temp_dir"
+        return 0
+    fi
+
+    # Create install directory if it doesn't exist
+    mkdir -p "$INSTALL_DIR"
+
+    # Install the binary
+    info "Installing to ${INSTALL_DIR}/${BINARY_NAME}..."
+    mv "$binary_path" "${INSTALL_DIR}/${BINARY_NAME}"
+    chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
+
+    # Cleanup
+    rm -rf "$temp_dir"
+}
+
+# Check if install directory is in PATH
+check_path() {
+    if [[ ":$PATH:" != *":${INSTALL_DIR}:"* ]]; then
+        warn "${INSTALL_DIR} is not in your PATH"
+        echo ""
+        echo "Add it to your PATH by adding this line to your shell profile:"
+        echo ""
+
+        if [ -n "$ZSH_VERSION" ]; then
+            echo "  echo 'export PATH=\"\$PATH:${INSTALL_DIR}\"' >> ~/.zshrc"
+            echo "  source ~/.zshrc"
+        elif [ -n "$BASH_VERSION" ]; then
+            echo "  echo 'export PATH=\"\$PATH:${INSTALL_DIR}\"' >> ~/.bashrc"
+            echo "  source ~/.bashrc"
+        else
+            echo "  export PATH=\"\$PATH:${INSTALL_DIR}\""
+        fi
+        echo ""
+    fi
+}
+
+# Uninstall Pipedrive CLI
+uninstall_pipedrive() {
+    echo "==================================="
+    echo "  Pipedrive CLI Uninstaller"
+    echo "==================================="
+    echo ""
+
+    local binary_path="${INSTALL_DIR}/${BINARY_NAME}"
+    local config_dir="${HOME}/.pipedrive"
+    local removed_something=false
+
+    # Remove binary
+    if [ -f "$binary_path" ]; then
+        info "Removing binary from $binary_path"
+        rm "$binary_path" || error "Failed to remove binary"
+        info "Binary removed successfully"
+        removed_something=true
+    else
+        warn "Binary not found at $binary_path"
+    fi
+
+    # Ask about config removal
+    if [ -d "$config_dir" ]; then
+        echo ""
+        echo -n "Remove configuration directory $config_dir? [y/N]: "
+        read -r response
+        if [[ "$response" =~ ^[Yy]$ ]]; then
+            rm -rf "$config_dir" || error "Failed to remove configuration directory"
+            info "Configuration directory removed"
+            removed_something=true
+        else
+            info "Configuration directory preserved"
+        fi
+    fi
+
+    echo ""
+    if [ "$removed_something" = true ]; then
+        info "Uninstall completed successfully"
+    else
+        warn "Nothing was removed - Pipedrive CLI may not have been installed"
+    fi
+
+    # Check if install directory is now empty and removable
+    if [ -d "$INSTALL_DIR" ] && [ -z "$(ls -A "$INSTALL_DIR" 2>/dev/null)" ]; then
+        echo ""
+        echo -n "Remove empty installation directory $INSTALL_DIR? [y/N]: "
+        read -r response
+        if [[ "$response" =~ ^[Yy]$ ]]; then
+            rmdir "$INSTALL_DIR" 2>/dev/null && info "Installation directory removed" || warn "Could not remove installation directory"
+        fi
+    fi
+}
+
+# Main installation flow
+main() {
+    # Parse command line arguments
+    local dry_run=false
+    local include_beta=false
+    local uninstall=false
+
+    for arg in "$@"; do
+        case $arg in
+            --dry-run|--dry|-n)
+                dry_run=true
+                ;;
+            --beta|--pre|--prerelease)
+                include_beta=true
+                ;;
+            --uninstall|--remove)
+                uninstall=true
+                ;;
+            --help|-h)
+                echo "Usage: $0 [OPTIONS]"
+                echo ""
+                echo "Options:"
+                echo "  --dry-run, -n       Download and verify but don't install"
+                echo "  --beta, --pre       Include beta/pre-release versions"
+                echo "  --uninstall         Remove Pipedrive CLI and optionally config"
+                echo "  --help, -h          Show this help message"
+                echo ""
+                echo "Environment variables:"
+                echo "  INSTALL_DIR         Set custom installation directory (default: ~/.local/bin)"
+                exit 0
+                ;;
+        esac
+    done
+
+    # Handle uninstall
+    if [ "$uninstall" = true ]; then
+        uninstall_pipedrive
+        exit 0
+    fi
+
+    echo "==================================="
+    echo "  Pipedrive CLI Installer"
+    echo "==================================="
+    echo ""
+
+    if [ "$dry_run" = true ]; then
+        warn "Running in DRY-RUN mode - will download but not install"
+        echo ""
+    fi
+
+    # Check requirements
+    check_requirements
+
+    # Detect platform
+    local platform
+    platform=$(detect_platform)
+    info "Detected platform: ${platform}"
+
+    # Get latest version
+    if [ "$include_beta" = true ]; then
+        info "Fetching latest release information (including pre-releases)..."
+    else
+        info "Fetching latest stable release information..."
+    fi
+    local version
+    version=$(get_latest_version "$include_beta")
+    info "Latest version: ${version}"
+
+    if [ "$include_beta" = true ] && [[ "$version" =~ (beta|rc|alpha|preview) ]]; then
+        warn "Installing pre-release version: ${version}"
+    fi
+
+    # Check if already installed
+    if [ -f "${INSTALL_DIR}/${BINARY_NAME}" ]; then
+        local current_version
+        current_version=$("${INSTALL_DIR}/${BINARY_NAME}" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+        warn "Existing installation found (version: ${current_version})"
+
+        read -p "Do you want to overwrite it? [y/N] " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            echo "Installation cancelled"
+            exit 0
+        fi
+    fi
+
+    # Install binary
+    install_binary "$version" "$platform" "$dry_run"
+
+    if [ "$dry_run" = true ]; then
+        echo ""
+        info "DRY-RUN complete! No changes were made to your system."
+        info "To actually install, run without --dry-run flag"
+    else
+        # Verify installation
+        if "${INSTALL_DIR}/${BINARY_NAME}" --version >/dev/null 2>&1; then
+            info "✓ Successfully installed ${BINARY_NAME} ${version}"
+        else
+            error "Installation verification failed"
+        fi
+
+        # Check PATH
+        check_path
+
+        echo ""
+        echo "Installation complete! 🎉"
+        echo ""
+        echo "Run '${BINARY_NAME} --help' to get started"
+        echo "Run '${BINARY_NAME} config set-api-token <token>' to configure"
+    fi
+}
+
+# Run main function
+main "$@"


### PR DESCRIPTION
## Summary
Adds comprehensive installation scripts for both Linux/macOS and Windows platforms, following the same proven pattern used in the freshdesk-cli project.

## Changes

### install.sh (Bash installer for Linux/macOS)
- **Multi-architecture support**: Detects and supports x64, arm64, and arm platforms
- **Platform detection**: Automatically detects Linux and macOS
- **Dry-run mode**: Test downloads without installing (`--dry-run`)
- **Beta/pre-release support**: Install pre-release versions with `--beta` flag
- **Uninstall functionality**: Remove binary and optionally config with `--uninstall`
- **PATH management**: Detects if install directory is in PATH and provides instructions
- **GitHub releases integration**: Downloads from GitHub releases automatically
- **Version checking**: Detects existing installations and prompts before overwriting
- **Comprehensive help**: `--help` flag shows all options and usage examples

### install.ps1 (PowerShell installer for Windows)
- **Multi-architecture support**: Detects and supports x64 and x86 platforms
- **Dry-run mode**: Test downloads without installing (`-DryRun`)
- **Beta/pre-release support**: Install pre-release versions with `-Beta` flag
- **PATH management**: Automatically adds install directory to user PATH
- **Desktop shortcut**: Optional desktop shortcut creation
- **GitHub releases integration**: Downloads from GitHub releases automatically
- **Version checking**: Detects existing installations and prompts before overwriting
- **Comprehensive help**: `-Help` parameter shows all options and examples

## Usage Examples

### Linux/macOS
```bash
# Quick install (piped from GitHub)
curl -sSL https://raw.githubusercontent.com/stannardlabs/pipedrive-cli/dev/install.sh | bash

# Download and run
./install.sh
./install.sh --dry-run
./install.sh --beta
INSTALL_DIR=/custom/path ./install.sh

# Uninstall
./install.sh --uninstall
```

### Windows
```powershell
# Quick install (piped from GitHub)
iwr -useb https://raw.githubusercontent.com/stannardlabs/pipedrive-cli/dev/install.ps1 | iex

# Download and run
.\install.ps1
.\install.ps1 -DryRun
.\install.ps1 -Beta -Force
.\install.ps1 -InstallDir 'C:\tools\pipedrive'
```

## Technical Details
- Both scripts follow identical logic and feature parity
- Error handling with clear, colored output messages
- Cleanup of temporary files after installation
- Binary verification post-install with `--version` check
- Support for custom installation directories via environment variable or parameter
- Configuration directory: `~/.pipedrive`
- Default install locations:
  - Linux/macOS: `~/.local/bin`
  - Windows: `%LOCALAPPDATA%\Programs\pipedrive`

## Testing
Scripts have been structured to match the battle-tested freshdesk-cli installers. They will be fully functional once the first GitHub release is published with the appropriate binary artifacts.

## Related
These scripts will be referenced in the README for installation instructions once releases are available.