### PR TITLE
Add support for beta/pre-release updates with --beta flag

### DIFF
--- a/src/PipedriveCLI/Commands/UpdateCommands.cs
+++ b/src/PipedriveCLI/Commands/UpdateCommands.cs
@@ -21,18 +21,24 @@ public static class UpdateCommands
             "Skip confirmation prompt"
         );
 
+        var betaOption = new Option<bool>(
+            new[] { "--beta", "-b" },
+            "Include beta/pre-release versions"
+        );
+
         updateCommand.AddOption(checkOption);
         updateCommand.AddOption(forceOption);
+        updateCommand.AddOption(betaOption);
 
-        updateCommand.SetHandler(async (checkOnly, force) =>
+        updateCommand.SetHandler(async (checkOnly, force, beta) =>
         {
-            await HandleUpdateCommand(checkOnly, force);
-        }, checkOption, forceOption);
+            await HandleUpdateCommand(checkOnly, force, beta);
+        }, checkOption, forceOption, betaOption);
 
         return updateCommand;
     }
 
-    private static async Task<int> HandleUpdateCommand(bool checkOnly, bool force)
+    private static async Task<int> HandleUpdateCommand(bool checkOnly, bool force, bool includeBeta)
     {
         // Get version information from assembly
         var assembly = Assembly.GetExecutingAssembly();
@@ -44,16 +50,26 @@ public static class UpdateCommands
             using var httpClient = new HttpClient();
             var updateService = new UpdateService(httpClient, currentVersion);
 
-            AnsiConsole.MarkupLine("[bold]Checking for updates...[/]");
-            var update = await updateService.CheckForUpdateAsync();
+            if (includeBeta)
+            {
+                AnsiConsole.MarkupLine("[bold]Checking for updates (including beta/pre-releases)...[/]");
+            }
+            else
+            {
+                AnsiConsole.MarkupLine("[bold]Checking for updates...[/]");
+            }
+
+            var update = await updateService.CheckForUpdateAsync(includeBeta);
 
             if (update == null)
             {
-                AnsiConsole.MarkupLine($"[green]✓[/] You're running the latest version (v{currentVersion})");
+                var versionType = includeBeta ? "version (including pre-releases)" : "stable version";
+                AnsiConsole.MarkupLine($"[green]✓[/] You're running the latest {versionType} (v{currentVersion})");
                 return 0;
             }
 
-            var panel = new Panel(new Markup($"[yellow]New version available:[/] [bold]v{update.Version}[/]\n[dim]Current version: v{currentVersion}[/]"))
+            var versionLabel = update.IsPrerelease ? "[yellow]New pre-release available:[/]" : "[yellow]New version available:[/]";
+            var panel = new Panel(new Markup($"{versionLabel} [bold]v{update.Version}[/]\n[dim]Current version: v{currentVersion}[/]"))
             {
                 Border = BoxBorder.Rounded,
                 BorderStyle = new Style(Color.Yellow)

--- a/src/PipedriveCLI/Services/UpdateService.cs
+++ b/src/PipedriveCLI/Services/UpdateService.cs
@@ -8,13 +8,14 @@ namespace PipedriveCLI.Services;
 
 public interface IUpdateService
 {
-    Task<UpdateInfo?> CheckForUpdateAsync(CancellationToken cancellationToken = default);
+    Task<UpdateInfo?> CheckForUpdateAsync(bool includePrereleases = false, CancellationToken cancellationToken = default);
     Task<bool> PerformUpdateAsync(UpdateInfo update, CancellationToken cancellationToken = default);
 }
 
 public sealed class UpdateService : IUpdateService
 {
-    private const string GITHUB_API_URL = "https://api.github.com/repos/Aaronontheweb/pipedrive-cli/releases/latest";
+    private const string GITHUB_API_URL_LATEST = "https://api.github.com/repos/Aaronontheweb/pipedrive-cli/releases/latest";
+    private const string GITHUB_API_URL_ALL = "https://api.github.com/repos/Aaronontheweb/pipedrive-cli/releases";
     private readonly HttpClient _httpClient;
     private readonly string _currentVersion;
 
@@ -30,12 +31,30 @@ public sealed class UpdateService : IUpdateService
         }
     }
 
-    public async Task<UpdateInfo?> CheckForUpdateAsync(CancellationToken cancellationToken = default)
+    public async Task<UpdateInfo?> CheckForUpdateAsync(bool includePrereleases = false, CancellationToken cancellationToken = default)
     {
         try
         {
-            var response = await _httpClient.GetStringAsync(GITHUB_API_URL, cancellationToken);
-            var release = JsonSerializer.Deserialize(response, UpdateJsonContext.Default.GitHubRelease);
+            GitHubRelease? release = null;
+
+            if (includePrereleases)
+            {
+                // Get all releases and find the latest one (including pre-releases)
+                var response = await _httpClient.GetStringAsync(GITHUB_API_URL_ALL, cancellationToken);
+                var releases = JsonSerializer.Deserialize(response, UpdateJsonContext.Default.GitHubReleaseArray);
+
+                if (releases != null && releases.Length > 0)
+                {
+                    // Get the first release (most recent)
+                    release = releases[0];
+                }
+            }
+            else
+            {
+                // Get only the latest stable release
+                var response = await _httpClient.GetStringAsync(GITHUB_API_URL_LATEST, cancellationToken);
+                release = JsonSerializer.Deserialize(response, UpdateJsonContext.Default.GitHubRelease);
+            }
 
             if (release == null)
                 return null;
@@ -56,7 +75,8 @@ public sealed class UpdateService : IUpdateService
                         DownloadUrl = asset.BrowserDownloadUrl,
                         FileName = asset.Name,
                         ReleaseNotes = release.Body,
-                        PublishedAt = release.PublishedAt
+                        PublishedAt = release.PublishedAt,
+                        IsPrerelease = release.Prerelease
                     };
                 }
             }
@@ -355,6 +375,7 @@ public sealed class UpdateInfo
     public required string FileName { get; init; }
     public string? ReleaseNotes { get; init; }
     public DateTimeOffset PublishedAt { get; init; }
+    public bool IsPrerelease { get; init; }
 }
 
 public sealed class GitHubRelease
@@ -367,6 +388,9 @@ public sealed class GitHubRelease
 
     [JsonPropertyName("published_at")]
     public DateTimeOffset PublishedAt { get; init; }
+
+    [JsonPropertyName("prerelease")]
+    public bool Prerelease { get; init; }
 
     [JsonPropertyName("assets")]
     public required GitHubAsset[] Assets { get; init; }
@@ -386,6 +410,7 @@ public sealed class GitHubAsset
 
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
 [JsonSerializable(typeof(GitHubRelease))]
+[JsonSerializable(typeof(GitHubRelease[]))]
 [JsonSerializable(typeof(GitHubAsset))]
 [JsonSerializable(typeof(GitHubAsset[]))]
 internal partial class UpdateJsonContext : JsonSerializerContext


### PR DESCRIPTION
## Summary

- Added `--beta` flag to `pipedrive update` command to allow users to explicitly opt into beta/pre-release versions
- Modified `UpdateService.CheckForUpdateAsync()` to support fetching all releases (including pre-releases) when requested
- Updated UI to distinguish between stable and pre-release versions
- Added `IsPrerelease` property to `UpdateInfo` and `GitHubRelease` models
- Added `GitHubRelease[]` to JSON source generation context for array deserialization

## Changes

### UpdateService.cs
- Added `GITHUB_API_URL_ALL` constant for fetching all releases
- Modified `CheckForUpdateAsync()` to accept `includePrereleases` parameter
- Conditional logic to fetch all releases vs. latest stable based on flag
- Added `IsPrerelease` property to `UpdateInfo` and `GitHubRelease` classes
- Updated `UpdateJsonContext` to include `GitHubRelease[]` for deserialization

### UpdateCommands.cs
- Added `--beta/-b` option to update command
- Modified handler to pass `includeBeta` to `CheckForUpdateAsync()`
- Updated status messages to indicate when checking for pre-releases
- Display "New pre-release available" vs "New version available" based on release type

## Testing

```bash
# Check for updates including beta versions
pipedrive update --beta --check

# Install beta version without confirmation
pipedrive update --beta --force
```

## Related Issues

Addresses user request for explicit beta update support.