### PR TITLE
Release 0.1.0-beta3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,50 +7,25 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.1.0-beta2</VersionPrefix>
-    <PackageReleaseNotes>This release adds comprehensive auto-update functionality to the Pipedrive CLI, making it easy to stay up-to-date with the latest features and improvements.
+    <VersionPrefix>0.1.0-beta3</VersionPrefix>
+    <PackageReleaseNotes>**CRITICAL HOTFIX RELEASE** - All users of 0.1.0-beta2 must upgrade immediately.
 
-**New Features**
+**Bug Fixes**
 
-- **Auto-Update System** ([#12](https://github.com/Aaronontheweb/pipedrive-cli/pull/12))
-  - Background update checking on CLI startup (non-blocking, 3-second timeout)
-  - Update notification banner when newer version available
-  - `pipedrive update` command with multiple options:
-    - `--check` - Check for updates without installing
-    - `--force` - Install updates without confirmation prompt
-  - Platform-specific self-update mechanism (Windows PowerShell, Unix bash)
-  - Automatic backup and rollback on update failure
-  - Progress indicators for download operations
-  - Support for tar.gz (Unix) and zip (Windows) archives
-  - GitHub releases integration via REST API
-  - AOT-compatible JSON serialization with source generators
-
-- **Beta/Pre-release Update Support** ([#13](https://github.com/Aaronontheweb/pipedrive-cli/pull/13))
-  - `--beta` flag to opt into pre-release updates
-  - Default behavior checks stable releases only
-  - Clear distinction between stable and pre-release versions in notifications
-  - Usage:
-    - `pipedrive update --beta` - Update to latest including betas
-    - `pipedrive update --beta --check` - Check for beta without installing
-    - `pipedrive update --beta --force` - Install beta without confirmation
-
-**Improvements**
-
-- Fixed installation scripts to use correct repository owner
-- Simplified release notes to focus on installation instructions
+- **Fixed API URL Construction Bug** (commit 8464db1)
+  - **Impact**: All API operations in 0.1.0-beta2 were completely broken, returning 401 Unauthorized errors
+  - **Root Cause**: `UriBuilder.Path` was replacing the entire path, removing the `/api/v1/` prefix from API requests
+  - **Symptom**: Requests were going to `https://domain.com/leads` instead of `https://domain.com/api/v1/leads`
+  - **Resolution**: Fixed URL construction to preserve the BaseAddress path when HttpClient makes requests
+  - **Result**: All API endpoints (leads, deals, activities, persons, organizations) now work correctly
 
 **Technical Details**
 
-- Version comparison using semantic versioning
-- Platform detection (linux-x64, win-x64, osx-x64, osx-arm64)
-- Binary download with progress tracking
-- Archive extraction with proper error handling
-- Self-replacement with backup/rollback capability
-- Silent failure on background check errors to prevent CLI delays
+The bug was introduced by using `UriBuilder.Path` to set the endpoint path, which replaces the entire path component of the URI rather than appending to it. This caused the `/api/v1/` prefix from the HttpClient's BaseAddress to be stripped out.
+
+The fix constructs the relative URL path directly as a string, allowing HttpClient to properly combine it with the BaseAddress that includes the `/api/v1/` prefix.
 
 **Installation**
-
-The installation scripts now support beta releases:
 
 ```bash
 # Linux/macOS
@@ -60,7 +35,7 @@ curl -fsSL https://raw.githubusercontent.com/Aaronontheweb/pipedrive-cli/dev/ins
 iwr https://raw.githubusercontent.com/Aaronontheweb/pipedrive-cli/dev/install.ps1 -useb | iex
 ```
 
-Or download binaries directly from the [releases page](https://github.com/Aaronontheweb/pipedrive-cli/releases/tag/0.1.0-beta2).
+Or download binaries directly from the [releases page](https://github.com/Aaronontheweb/pipedrive-cli/releases/tag/0.1.0-beta3).
 
 ---</PackageReleaseNotes>
   </PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,36 @@
+#### 0.1.0-beta3 January 4th 2025 ####
+
+**CRITICAL HOTFIX RELEASE** - All users of 0.1.0-beta2 must upgrade immediately.
+
+**Bug Fixes**
+
+- **Fixed API URL Construction Bug** (commit 8464db1)
+  - **Impact**: All API operations in 0.1.0-beta2 were completely broken, returning 401 Unauthorized errors
+  - **Root Cause**: `UriBuilder.Path` was replacing the entire path, removing the `/api/v1/` prefix from API requests
+  - **Symptom**: Requests were going to `https://domain.com/leads` instead of `https://domain.com/api/v1/leads`
+  - **Resolution**: Fixed URL construction to preserve the BaseAddress path when HttpClient makes requests
+  - **Result**: All API endpoints (leads, deals, activities, persons, organizations) now work correctly
+
+**Technical Details**
+
+The bug was introduced by using `UriBuilder.Path` to set the endpoint path, which replaces the entire path component of the URI rather than appending to it. This caused the `/api/v1/` prefix from the HttpClient's BaseAddress to be stripped out.
+
+The fix constructs the relative URL path directly as a string, allowing HttpClient to properly combine it with the BaseAddress that includes the `/api/v1/` prefix.
+
+**Installation**
+
+```bash
+# Linux/macOS
+curl -fsSL https://raw.githubusercontent.com/Aaronontheweb/pipedrive-cli/dev/install.sh | bash -s -- --beta
+
+# Windows PowerShell
+iwr https://raw.githubusercontent.com/Aaronontheweb/pipedrive-cli/dev/install.ps1 -useb | iex
+```
+
+Or download binaries directly from the [releases page](https://github.com/Aaronontheweb/pipedrive-cli/releases/tag/0.1.0-beta3).
+
+---
+
 #### 0.1.0-beta2 January 4th 2025 ####
 
 This release adds comprehensive auto-update functionality to the Pipedrive CLI, making it easy to stay up-to-date with the latest features and improvements.


### PR DESCRIPTION
## Critical Hotfix Release

This PR prepares version 0.1.0-beta3, a critical hotfix release to address a severe bug in 0.1.0-beta2 that broke all API operations.

## Changes in this Release

### Bug Fix
- Fixed API URL construction bug in `BuildUrlWithApiKeyAsync` that caused all API requests to fail with 401 Unauthorized errors

### Root Cause
The `UriBuilder.Path` property was replacing the entire path, removing the `/api/v1/` prefix from API requests. This caused requests to go to `https://domain.com/leads` instead of `https://domain.com/api/v1/leads`.

### Resolution
Fixed URL construction to directly build the relative URL path as a string, allowing HttpClient to properly combine it with the BaseAddress that includes the `/api/v1/` prefix.

## Impact
All users of 0.1.0-beta2 must upgrade immediately as all API endpoints (leads, deals, activities, persons, organizations) were completely non-functional.

## Files Changed
- `RELEASE_NOTES.md` - Added release notes for 0.1.0-beta3
- `Directory.Build.props` - Updated version to 0.1.0-beta3 and package release notes

## Next Steps
After merge:
1. Tag release as `0.1.0-beta3` (no 'v' prefix)
2. Push tag to trigger GitHub release workflow
3. Release workflow will build and publish binaries for all platforms