### PR TITLE
Fix API model serialization and Owner type handling

### DIFF
--- a/src/PipedriveCLI.Tests/OrganizationsApiClientTests.cs
+++ b/src/PipedriveCLI.Tests/OrganizationsApiClientTests.cs
@@ -15,7 +15,7 @@ public class OrganizationsApiClientTests
     [Fact]
     public void Organization_Deserialization_HandlesFullApiResponse()
     {
-        // Arrange - Full API response with all fields
+        // Arrange - Full API response with all fields (owner_id is an object in real API)
         var json = """
         {
             "success": true,
@@ -23,7 +23,12 @@ public class OrganizationsApiClientTests
                 "id": 123,
                 "name": "Acme Corporation",
                 "people_count": 50,
-                "owner_id": 456,
+                "owner_id": {
+                    "id": 456,
+                    "name": "John Smith",
+                    "email": "john@example.com",
+                    "value": 456
+                },
                 "address": "123 Main St, San Francisco, CA 94105",
                 "add_time": "2024-01-15T10:30:00Z",
                 "update_time": "2024-01-16T14:20:00Z"
@@ -41,7 +46,9 @@ public class OrganizationsApiClientTests
         Assert.Equal(123, response.Data.Id);
         Assert.Equal("Acme Corporation", response.Data.Name);
         Assert.Equal(50, response.Data.PeopleCount);
-        Assert.Equal(456, response.Data.OwnerId);
+        Assert.NotNull(response.Data.OwnerId);
+        Assert.Equal(456, response.Data.OwnerId.Id);
+        Assert.Equal("John Smith", response.Data.OwnerId.Name);
         Assert.Equal("123 Main St, San Francisco, CA 94105", response.Data.Address);
         Assert.Equal("2024-01-15T10:30:00Z", response.Data.AddTime);
         Assert.Equal("2024-01-16T14:20:00Z", response.Data.UpdateTime);
@@ -53,7 +60,7 @@ public class OrganizationsApiClientTests
     [Fact]
     public void OrganizationsList_Deserialization_WithPagination()
     {
-        // Arrange
+        // Arrange - API returns owner_id as an object
         var json = """
         {
             "success": true,
@@ -62,7 +69,12 @@ public class OrganizationsApiClientTests
                     "id": 100,
                     "name": "Tech Startup Inc",
                     "people_count": 25,
-                    "owner_id": 200,
+                    "owner_id": {
+                        "id": 200,
+                        "name": "Jane Doe",
+                        "email": "jane@example.com",
+                        "value": 200
+                    },
                     "address": "456 Innovation Way, Austin, TX 78701",
                     "add_time": "2024-01-01T10:00:00Z",
                     "update_time": "2024-01-01T10:00:00Z"
@@ -102,7 +114,9 @@ public class OrganizationsApiClientTests
         Assert.Equal(100, org1.Id);
         Assert.Equal("Tech Startup Inc", org1.Name);
         Assert.Equal(25, org1.PeopleCount);
-        Assert.Equal(200, org1.OwnerId);
+        Assert.NotNull(org1.OwnerId);
+        Assert.Equal(200, org1.OwnerId.Id);
+        Assert.Equal("Jane Doe", org1.OwnerId.Name);
         Assert.Equal("456 Innovation Way, Austin, TX 78701", org1.Address);
 
         // Second organization
@@ -220,7 +234,7 @@ public class OrganizationsApiClientTests
                 "id": 600,
                 "name": "Large Corporation",
                 "people_count": 10000,
-                "owner_id": 999,
+                "owner_id": null,
                 "address": "1 Corporate Plaza, Chicago, IL 60601",
                 "add_time": "2024-01-01T00:00:00Z",
                 "update_time": "2024-01-01T00:00:00Z"
@@ -284,7 +298,7 @@ public class OrganizationsApiClientTests
                 "id": 700,
                 "name": "Remote Company",
                 "people_count": 15,
-                "owner_id": 123,
+                "owner_id": null,
                 "address": null,
                 "add_time": "2024-03-01T00:00:00Z",
                 "update_time": "2024-03-01T00:00:00Z"

--- a/src/PipedriveCLI/Commands/OrganizationsCommands.cs
+++ b/src/PipedriveCLI/Commands/OrganizationsCommands.cs
@@ -80,7 +80,7 @@ public static class OrganizationsCommands
                                     org.Name ?? "-",
                                     org.PeopleCount.ToString(),
                                     org.Address ?? "-",
-                                    org.OwnerId?.ToString() ?? "-",
+                                    org.OwnerId?.Id.ToString() ?? "-",
                                     org.AddTime ?? "-"
                                 );
                             }
@@ -104,7 +104,7 @@ public static class OrganizationsCommands
             }
             catch (Exception ex)
             {
-                AnsiConsole.MarkupLine($"[red]Error:[/] {ex.Message}");
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
             }
         }, limitOption, startOption);
 
@@ -138,17 +138,20 @@ public static class OrganizationsCommands
                 if (response?.Success == true && response.Data != null)
                 {
                     var org = response.Data;
+                    var ownerInfo = org.OwnerId != null
+                        ? $"{org.OwnerId.Id} ({org.OwnerId.Name})"
+                        : "N/A";
 
                     var panel = new Panel(new Markup(
-                        $"[bold]Name:[/] {org.Name}\n" +
+                        $"[bold]Name:[/] {Markup.Escape(org.Name ?? "")}\n" +
                         $"[bold]ID:[/] {org.Id}\n" +
                         $"[bold]People Count:[/] {org.PeopleCount}\n" +
-                        $"[bold]Address:[/] {org.Address ?? "N/A"}\n" +
-                        $"[bold]Owner ID:[/] {org.OwnerId?.ToString() ?? "N/A"}\n" +
-                        $"[bold]Added:[/] {org.AddTime}\n" +
-                        $"[bold]Updated:[/] {org.UpdateTime}"))
+                        $"[bold]Address:[/] {Markup.Escape(org.Address ?? "N/A")}\n" +
+                        $"[bold]Owner:[/] {Markup.Escape(ownerInfo)}\n" +
+                        $"[bold]Added:[/] {Markup.Escape(org.AddTime ?? "N/A")}\n" +
+                        $"[bold]Updated:[/] {Markup.Escape(org.UpdateTime ?? "N/A")}"))
                     {
-                        Header = new PanelHeader($"[green]Organization: {org.Name}[/]"),
+                        Header = new PanelHeader($"[green]Organization: {Markup.Escape(org.Name ?? "")}[/]"),
                         Border = BoxBorder.Rounded
                     };
 
@@ -161,7 +164,7 @@ public static class OrganizationsCommands
             }
             catch (Exception ex)
             {
-                AnsiConsole.MarkupLine($"[red]Error:[/] {ex.Message}");
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
             }
         }, idArgument);
 
@@ -209,18 +212,18 @@ public static class OrganizationsCommands
 
                 if (response?.Success == true && response.Data != null)
                 {
-                    AnsiConsole.MarkupLine($"[green]✓[/] Organization created successfully");
-                    AnsiConsole.MarkupLine($"[dim]ID:[/] {response.Data.Id}");
-                    AnsiConsole.MarkupLine($"[dim]Name:[/] {response.Data.Name}");
+                    AnsiConsole.MarkupLine("[green]✓[/] Organization created successfully");
+                    AnsiConsole.MarkupLine($"[dim]ID:[/] {Markup.Escape(response.Data.Id.ToString())}");
+                    AnsiConsole.MarkupLine($"[dim]Name:[/] {Markup.Escape(response.Data.Name ?? "")}");
                 }
                 else
                 {
-                    AnsiConsole.MarkupLine($"[red]✗[/] Failed to create organization: {response?.Error ?? "Unknown error"}");
+                    AnsiConsole.MarkupLine($"[red]✗[/] Failed to create organization: {Markup.Escape(response?.Error ?? "Unknown error")}");
                 }
             }
             catch (Exception ex)
             {
-                AnsiConsole.MarkupLine($"[red]Error:[/] {ex.Message}");
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
             }
         }, nameOption, addressOption);
 
@@ -284,7 +287,7 @@ public static class OrganizationsCommands
             }
             catch (Exception ex)
             {
-                AnsiConsole.MarkupLine($"[red]Error:[/] {ex.Message}");
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
             }
         }, idArgument, nameOption, addressOption);
 
@@ -342,7 +345,7 @@ public static class OrganizationsCommands
             }
             catch (Exception ex)
             {
-                AnsiConsole.MarkupLine($"[red]Error:[/] {ex.Message}");
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
             }
         }, idArgument, forceOption);
 
@@ -416,7 +419,7 @@ public static class OrganizationsCommands
             }
             catch (Exception ex)
             {
-                AnsiConsole.MarkupLine($"[red]Error:[/] {ex.Message}");
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
             }
         }, termArgument, limitOption);
 

--- a/src/PipedriveCLI/Commands/OrganizationsCommands.cs
+++ b/src/PipedriveCLI/Commands/OrganizationsCommands.cs
@@ -405,7 +405,7 @@ public static class OrganizationsCommands
                             org.Name ?? "-",
                             org.PeopleCount.ToString(),
                             org.Address ?? "-",
-                            org.OwnerId?.ToString() ?? "-"
+                            org.OwnerId?.Id.ToString() ?? "-"
                         );
                     }
 

--- a/src/PipedriveCLI/Models/ApiModels.cs
+++ b/src/PipedriveCLI/Models/ApiModels.cs
@@ -214,6 +214,24 @@ public sealed class Phone
 }
 
 /// <summary>
+/// Pipedrive Owner/User reference
+/// </summary>
+public sealed class Owner
+{
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    [JsonPropertyName("value")]
+    public int Value { get; set; }
+}
+
+/// <summary>
 /// Pipedrive Organization model
 /// </summary>
 public sealed class Organization
@@ -228,7 +246,7 @@ public sealed class Organization
     public int PeopleCount { get; set; }
 
     [JsonPropertyName("owner_id")]
-    public int? OwnerId { get; set; }
+    public Owner? OwnerId { get; set; }
 
     [JsonPropertyName("address")]
     public string? Address { get; set; }
@@ -288,7 +306,7 @@ public sealed class Activity
 [JsonSourceGenerationOptions(
     WriteIndented = true,
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
-    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault)]
 [JsonSerializable(typeof(PipedriveResponse<object>))]
 [JsonSerializable(typeof(PipedriveResponse<Lead>))]
 [JsonSerializable(typeof(PipedriveResponse<List<Lead>>))]
@@ -310,6 +328,7 @@ public sealed class Activity
 [JsonSerializable(typeof(List<Person>))]
 [JsonSerializable(typeof(List<Organization>))]
 [JsonSerializable(typeof(List<Activity>))]
+[JsonSerializable(typeof(Owner))]
 internal partial class ApiJsonContext : JsonSerializerContext
 {
 }


### PR DESCRIPTION
## Summary
Fixes critical bugs in API model serialization and Organizations commands that were preventing successful API operations.

## Changes
- **JSON Serialization**: Changed `DefaultIgnoreCondition` from `WhenWritingNull` to `WhenWritingDefault` to prevent sending default values (like `id: 0`) in API requests
- **Owner Model**: Created new `Owner` model class to properly deserialize the `owner_id` field which the API returns as an object `{id, name, email, value}` rather than an integer
- **Markup Escaping**: Added `Markup.Escape()` calls throughout OrganizationsCommands to prevent Spectre.Console from interpreting API-returned values as style codes
- **Test Updates**: Updated OrganizationsApiClientTests to match the new Owner object format

## Test Results
✓ All 38 tests passing
✓ Successfully created organization "Acme Corporation" in sandbox environment

## Files Changed
- `src/PipedriveCLI/Models/ApiModels.cs` - Added Owner model, changed Organization.OwnerId type, fixed serialization
- `src/PipedriveCLI/Commands/OrganizationsCommands.cs` - Added Markup.Escape() calls, updated Owner display logic
- `src/PipedriveCLI.Tests/OrganizationsApiClientTests.cs` - Updated test JSON to use Owner object format