### PR TITLE
Add custom fields support for deals, persons, and organizations

### DIFF
--- a/src/PipedriveCLI/Commands/DealsCommands.cs
+++ b/src/PipedriveCLI/Commands/DealsCommands.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using PipedriveCLI.Models;
 using PipedriveCLI.Services;
+using PipedriveCLI.Utilities;
 using Spectre.Console;
 
 namespace PipedriveCLI.Commands;
@@ -151,6 +152,7 @@ public static class DealsCommands
                 if (response?.Success == true && response.Data != null)
                 {
                     var deal = response.Data;
+                    var customFieldsDisplay = CustomFieldHelper.FormatCustomFields(deal.CustomFields);
 
                     var panel = new Panel(new Markup(
                         $"[bold]Title:[/] {Markup.Escape(deal.Title ?? "")}\n" +
@@ -163,7 +165,8 @@ public static class DealsCommands
                         $"[bold]Probability:[/] {(deal.Probability.HasValue ? $"{deal.Probability.Value}%" : "N/A")}\n" +
                         $"[bold]Expected Close Date:[/] {Markup.Escape(deal.ExpectedCloseDate ?? "N/A")}\n" +
                         $"[bold]Added:[/] {Markup.Escape(deal.AddTime ?? "N/A")}\n" +
-                        $"[bold]Updated:[/] {Markup.Escape(deal.UpdateTime ?? "N/A")}"))
+                        $"[bold]Updated:[/] {Markup.Escape(deal.UpdateTime ?? "N/A")}" +
+                        customFieldsDisplay))
                     {
                         Header = new PanelHeader($"[green]Deal: {Markup.Escape(deal.Title ?? "")}[/]"),
                         Border = BoxBorder.Rounded

--- a/src/PipedriveCLI/Commands/OrganizationsCommands.cs
+++ b/src/PipedriveCLI/Commands/OrganizationsCommands.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using PipedriveCLI.Models;
 using PipedriveCLI.Services;
+using PipedriveCLI.Utilities;
 using Spectre.Console;
 
 namespace PipedriveCLI.Commands;
@@ -143,6 +144,8 @@ public static class OrganizationsCommands
                         ? $"{org.OwnerId.Id} ({org.OwnerId.Name})"
                         : "N/A";
 
+                    var customFieldsDisplay = CustomFieldHelper.FormatCustomFields(org.CustomFields);
+
                     var panel = new Panel(new Markup(
                         $"[bold]Name:[/] {Markup.Escape(org.Name ?? "")}\n" +
                         $"[bold]ID:[/] {org.Id}\n" +
@@ -150,7 +153,8 @@ public static class OrganizationsCommands
                         $"[bold]Address:[/] {Markup.Escape(org.Address ?? "N/A")}\n" +
                         $"[bold]Owner:[/] {Markup.Escape(ownerInfo)}\n" +
                         $"[bold]Added:[/] {Markup.Escape(org.AddTime ?? "N/A")}\n" +
-                        $"[bold]Updated:[/] {Markup.Escape(org.UpdateTime ?? "N/A")}"))
+                        $"[bold]Updated:[/] {Markup.Escape(org.UpdateTime ?? "N/A")}" +
+                        customFieldsDisplay))
                     {
                         Header = new PanelHeader($"[green]Organization: {Markup.Escape(org.Name ?? "")}[/]"),
                         Border = BoxBorder.Rounded

--- a/src/PipedriveCLI/Commands/PersonsCommands.cs
+++ b/src/PipedriveCLI/Commands/PersonsCommands.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using PipedriveCLI.Models;
 using PipedriveCLI.Services;
+using PipedriveCLI.Utilities;
 using Spectre.Console;
 
 namespace PipedriveCLI.Commands;
@@ -162,6 +163,8 @@ public static class PersonsCommands
                         ? $"{person.OwnerId.Id} ({person.OwnerId.Name})"
                         : "N/A";
 
+                    var customFieldsDisplay = CustomFieldHelper.FormatCustomFields(person.CustomFields);
+
                     var panel = new Panel(new Markup(
                         $"[bold]Name:[/] {Markup.Escape(person.Name ?? "")}\n" +
                         $"[bold]ID:[/] {person.Id}\n" +
@@ -172,7 +175,8 @@ public static class PersonsCommands
                         $"[bold]Organization ID:[/] {person.OrgId?.ToString() ?? "N/A"}\n" +
                         $"[bold]Owner:[/] {Markup.Escape(ownerInfo)}\n" +
                         $"[bold]Added:[/] {Markup.Escape(person.AddTime ?? "N/A")}\n" +
-                        $"[bold]Updated:[/] {Markup.Escape(person.UpdateTime ?? "N/A")}"))
+                        $"[bold]Updated:[/] {Markup.Escape(person.UpdateTime ?? "N/A")}" +
+                        customFieldsDisplay))
                     {
                         Header = new PanelHeader($"[green]Person: {Markup.Escape(person.Name ?? "")}[/]"),
                         Border = BoxBorder.Rounded

--- a/src/PipedriveCLI/Models/ApiModels.cs
+++ b/src/PipedriveCLI/Models/ApiModels.cs
@@ -313,6 +313,12 @@ public sealed class Deal
 
     [JsonPropertyName("expected_close_date")]
     public string? ExpectedCloseDate { get; set; }
+
+    /// <summary>
+    /// Custom fields - captured as extension data with hash keys
+    /// </summary>
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? CustomFields { get; set; }
 }
 
 /// <summary>
@@ -350,6 +356,12 @@ public sealed class Person
 
     [JsonPropertyName("update_time")]
     public string? UpdateTime { get; set; }
+
+    /// <summary>
+    /// Custom fields - captured as extension data with hash keys
+    /// </summary>
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? CustomFields { get; set; }
 }
 
 /// <summary>
@@ -425,6 +437,12 @@ public sealed class Organization
 
     [JsonPropertyName("update_time")]
     public string? UpdateTime { get; set; }
+
+    /// <summary>
+    /// Custom fields - captured as extension data with hash keys
+    /// </summary>
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? CustomFields { get; set; }
 }
 
 /// <summary>
@@ -539,6 +557,66 @@ public sealed class Note
 }
 
 /// <summary>
+/// Field definition option for select/multi-select fields
+/// </summary>
+public sealed class FieldOption
+{
+    [JsonPropertyName("id")]
+    public int? Id { get; set; }
+
+    [JsonPropertyName("label")]
+    public string? Label { get; set; }
+}
+
+/// <summary>
+/// Base field definition model for custom fields
+/// </summary>
+public abstract class BaseField
+{
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    [JsonPropertyName("key")]
+    public string? Key { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("field_type")]
+    public string? FieldType { get; set; }
+
+    [JsonPropertyName("edit_flag")]
+    public bool EditFlag { get; set; }
+
+    [JsonPropertyName("mandatory_flag")]
+    public bool MandatoryFlag { get; set; }
+
+    [JsonPropertyName("options")]
+    public List<FieldOption>? Options { get; set; }
+}
+
+/// <summary>
+/// Deal field definition
+/// </summary>
+public sealed class DealField : BaseField
+{
+}
+
+/// <summary>
+/// Person field definition
+/// </summary>
+public sealed class PersonField : BaseField
+{
+}
+
+/// <summary>
+/// Organization field definition
+/// </summary>
+public sealed class OrganizationField : BaseField
+{
+}
+
+/// <summary>
 /// JSON source generator context for API models (Native AOT compatibility)
 /// </summary>
 [JsonSourceGenerationOptions(
@@ -577,6 +655,15 @@ public sealed class Note
 [JsonSerializable(typeof(List<Activity>))]
 [JsonSerializable(typeof(List<Note>))]
 [JsonSerializable(typeof(Owner))]
+[JsonSerializable(typeof(DealField))]
+[JsonSerializable(typeof(PersonField))]
+[JsonSerializable(typeof(OrganizationField))]
+[JsonSerializable(typeof(List<DealField>))]
+[JsonSerializable(typeof(List<PersonField>))]
+[JsonSerializable(typeof(List<OrganizationField>))]
+[JsonSerializable(typeof(PipedriveResponse<List<DealField>>))]
+[JsonSerializable(typeof(PipedriveResponse<List<PersonField>>))]
+[JsonSerializable(typeof(PipedriveResponse<List<OrganizationField>>))]
 internal partial class ApiJsonContext : JsonSerializerContext
 {
 }

--- a/src/PipedriveCLI/Services/PipedriveApiClient.cs
+++ b/src/PipedriveCLI/Services/PipedriveApiClient.cs
@@ -576,6 +576,37 @@ public sealed class PipedriveApiClient : IDisposable
 
     #endregion
 
+    #region Custom Fields
+
+    /// <summary>
+    /// Gets all deal field definitions
+    /// </summary>
+    public async Task<PipedriveResponse<List<DealField>>?> GetDealFieldsAsync()
+    {
+        var jsonResponse = await GetAsync("dealFields");
+        return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseListDealField);
+    }
+
+    /// <summary>
+    /// Gets all person field definitions
+    /// </summary>
+    public async Task<PipedriveResponse<List<PersonField>>?> GetPersonFieldsAsync()
+    {
+        var jsonResponse = await GetAsync("personFields");
+        return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseListPersonField);
+    }
+
+    /// <summary>
+    /// Gets all organization field definitions
+    /// </summary>
+    public async Task<PipedriveResponse<List<OrganizationField>>?> GetOrganizationFieldsAsync()
+    {
+        var jsonResponse = await GetAsync("organizationFields");
+        return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseListOrganizationField);
+    }
+
+    #endregion
+
     /// <summary>
     /// Tests the API connection by making a simple request
     /// </summary>

--- a/src/PipedriveCLI/Utilities/CustomFieldHelper.cs
+++ b/src/PipedriveCLI/Utilities/CustomFieldHelper.cs
@@ -1,0 +1,102 @@
+using System.Text.Json;
+
+namespace PipedriveCLI.Utilities;
+
+/// <summary>
+/// Helper methods for working with custom fields
+/// </summary>
+public static class CustomFieldHelper
+{
+    /// <summary>
+    /// Formats custom fields into readable key-value pairs
+    /// Returns formatted string for display, or empty string if no custom fields
+    /// </summary>
+    public static string FormatCustomFields(Dictionary<string, JsonElement>? customFields)
+    {
+        if (customFields == null || customFields.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var lines = new List<string>();
+        foreach (var (key, value) in customFields)
+        {
+            // Skip standard Pipedrive fields (they don't have hash-like keys)
+            if (key.Length < 30) // Hash keys are 40+ characters
+                continue;
+
+            var formattedValue = FormatJsonElement(value);
+            lines.Add($"  [dim]{key}:[/] {formattedValue}");
+        }
+
+        return lines.Count > 0 ? "\n[bold]Custom Fields:[/]\n" + string.Join("\n", lines) : string.Empty;
+    }
+
+    /// <summary>
+    /// Formats a JsonElement into a readable string
+    /// </summary>
+    private static string FormatJsonElement(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => element.GetString() ?? "-",
+            JsonValueKind.Number => element.GetRawText(),
+            JsonValueKind.True => "Yes",
+            JsonValueKind.False => "No",
+            JsonValueKind.Null => "-",
+            JsonValueKind.Array => $"[{element.GetArrayLength()} items]",
+            JsonValueKind.Object => "[Object]",
+            _ => element.GetRawText()
+        };
+    }
+
+    /// <summary>
+    /// Parses custom field key-value pairs from command line arguments
+    /// Format: key1=value1,key2=value2
+    /// </summary>
+    public static Dictionary<string, JsonElement>? ParseCustomFields(string? customFieldsString)
+    {
+        if (string.IsNullOrWhiteSpace(customFieldsString))
+            return null;
+
+        var customFields = new Dictionary<string, JsonElement>();
+        var pairs = customFieldsString.Split(',', StringSplitOptions.RemoveEmptyEntries);
+
+        foreach (var pair in pairs)
+        {
+            var parts = pair.Split('=', 2);
+            if (parts.Length != 2)
+                continue;
+
+            var key = parts[0].Trim();
+            var value = parts[1].Trim();
+
+            // Try to parse as number, boolean, or string
+            // Use JsonDocument.Parse to create JsonElement in an AOT-compatible way
+            JsonElement element;
+            if (int.TryParse(value, out var intValue))
+            {
+                using var doc = JsonDocument.Parse(intValue.ToString());
+                element = doc.RootElement.Clone();
+            }
+            else if (bool.TryParse(value, out var boolValue))
+            {
+                using var doc = JsonDocument.Parse(boolValue.ToString().ToLower());
+                element = doc.RootElement.Clone();
+            }
+            else
+            {
+                // For strings, we need to escape and quote them properly
+                // Manually escape the string for JSON
+                var escaped = value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+                var jsonString = $"\"{escaped}\"";
+                using var doc = JsonDocument.Parse(jsonString);
+                element = doc.RootElement.Clone();
+            }
+
+            customFields[key] = element;
+        }
+
+        return customFields.Count > 0 ? customFields : null;
+    }
+}


### PR DESCRIPTION
## Summary
Implements custom field display functionality for deals, persons, and organizations. Custom fields are now automatically shown when viewing individual entities using the CLI.

## Changes
- Added `CustomFields` property with `[JsonExtensionData]` to Deal, Person, and Organization models to capture Pipedrive's hash-based custom field keys (40+ characters)
- Created field definition models (DealField, PersonField, OrganizationField) with API methods to fetch field metadata
- Implemented `CustomFieldHelper` utility with AOT-compatible parsing and formatting methods
- Updated get commands for deals, persons, and organizations to display custom fields in a dedicated section
- Maintained Native AOT compatibility using JsonDocument instead of reflection-based serialization

## Testing
- ✅ Build passes (Release configuration)
- ✅ Native AOT compatibility verified
- Custom fields automatically displayed in get command output for entities with custom data

## Usage
Custom fields now appear automatically when running:
- `pipedrive deals get <id>`
- `pipedrive persons get <id>`
- `pipedrive organizations get <id>`

All custom fields with hash keys are displayed in a "Custom Fields" section at the bottom of the entity details.