### PR TITLE
Add --profile flag to config set command

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ pipedrive config get  # Will show the overridden value
 
 ### Managing Profiles
 
+**Create a new profile with credentials:**
+```bash
+# Create and configure a new profile without switching
+pipedrive config set --profile staging --api-key STAGING_KEY --domain staging.pipedrive.com
+```
+
 **List all profiles:**
 ```bash
 pipedrive config profile list
@@ -103,7 +109,7 @@ pipedrive config profile list
 pipedrive config profile switch staging
 ```
 
-**Set configuration for a specific profile:**
+**Alternative: Set configuration for a specific profile after switching:**
 ```bash
 # First switch to the profile
 pipedrive config profile switch staging
@@ -120,15 +126,22 @@ Manage CLI configuration and profiles.
 
 #### `config set` - Set Configuration Values
 
-Set one or more configuration values for the active profile.
+Set one or more configuration values for the active profile or a specific profile.
 
 ```bash
-# Set API key and domain
+# Set API key and domain for the active profile
 pipedrive config set --api-key YOUR_KEY --domain company.pipedrive.com
 
+# Create and configure a new profile without switching to it
+pipedrive config set --profile staging --api-key STAGING_KEY --domain staging.pipedrive.com
+
+# Update a specific profile's API key
+pipedrive config set --profile production --api-key PROD_KEY
+
 # Options:
-#   --api-key, -k    Pipedrive API key
-#   --domain, -d     Pipedrive domain (e.g., company.pipedrive.com)
+#   --api-key, -k     Pipedrive API key
+#   --domain, -d      Pipedrive domain (e.g., company.pipedrive.com)
+#   --profile, -p     Profile name to configure (creates if it doesn't exist)
 ```
 
 #### `config get` - Display Current Configuration

--- a/src/PipedriveCLI/Commands/ConfigCommands.cs
+++ b/src/PipedriveCLI/Commands/ConfigCommands.cs
@@ -40,10 +40,15 @@ public static class ConfigCommands
             aliases: new[] { "--domain", "-d" },
             description: "Pipedrive domain (e.g., company.pipedrive.com)");
 
+        var profileOption = new Option<string?>(
+            aliases: new[] { "--profile", "-p" },
+            description: "Profile name to configure (creates if it doesn't exist). If not specified, uses the active profile.");
+
         setCommand.AddOption(apiKeyOption);
         setCommand.AddOption(domainOption);
+        setCommand.AddOption(profileOption);
 
-        setCommand.SetHandler(async (apiKey, domain) =>
+        setCommand.SetHandler(async (apiKey, domain, profile) =>
         {
             try
             {
@@ -54,24 +59,25 @@ public static class ConfigCommands
                     return;
                 }
 
-                await configService.SetConfigAsync(apiKey, domain);
+                await configService.SetConfigAsync(apiKey, domain, profile);
 
-                AnsiConsole.MarkupLine("[green]✓[/] Configuration updated successfully");
+                var targetProfile = profile ?? await configService.GetActiveProfileNameAsync();
+                AnsiConsole.MarkupLine($"[green]✓[/] Configuration updated successfully for profile: [cyan]{targetProfile}[/]");
 
                 // Show what was set
-                var profile = await configService.GetActiveProfileAsync();
-                var profileName = await configService.GetActiveProfileNameAsync();
+                var config = await configService.LoadConfigAsync();
+                var profileConfig = config.Profiles[targetProfile];
 
                 var table = new Table();
                 table.Border(TableBorder.Rounded);
                 table.AddColumn("Setting");
                 table.AddColumn("Value");
 
-                table.AddRow("Profile", $"[cyan]{profileName}[/]");
+                table.AddRow("Profile", $"[cyan]{targetProfile}[/]");
                 if (!string.IsNullOrWhiteSpace(apiKey))
-                    table.AddRow("API Key", $"[dim]{MaskApiKey(profile.ApiKey)}[/]");
+                    table.AddRow("API Key", $"[dim]{MaskApiKey(profileConfig.ApiKey)}[/]");
                 if (!string.IsNullOrWhiteSpace(domain))
-                    table.AddRow("Domain", $"[cyan]{profile.Domain}[/]");
+                    table.AddRow("Domain", $"[cyan]{profileConfig.Domain}[/]");
 
                 AnsiConsole.Write(table);
             }
@@ -79,7 +85,7 @@ public static class ConfigCommands
             {
                 AnsiConsole.MarkupLine($"[red]Error:[/] {ex.Message}");
             }
-        }, apiKeyOption, domainOption);
+        }, apiKeyOption, domainOption, profileOption);
 
         return setCommand;
     }

--- a/src/PipedriveCLI/Services/ConfigurationService.cs
+++ b/src/PipedriveCLI/Services/ConfigurationService.cs
@@ -144,17 +144,20 @@ public sealed class ConfigurationService
     /// <summary>
     /// Sets multiple configuration values at once
     /// </summary>
-    public async Task SetConfigAsync(string? apiKey = null, string? domain = null)
+    /// <param name="apiKey">Optional API key to set</param>
+    /// <param name="domain">Optional domain to set</param>
+    /// <param name="profileName">Optional profile name. If null, uses the active profile</param>
+    public async Task SetConfigAsync(string? apiKey = null, string? domain = null, string? profileName = null)
     {
         var config = await LoadConfigAsync();
-        var profileName = config.ActiveProfile;
+        var targetProfile = profileName ?? config.ActiveProfile;
 
-        if (!config.Profiles.ContainsKey(profileName))
+        if (!config.Profiles.ContainsKey(targetProfile))
         {
-            config.Profiles[profileName] = new ProfileConfig();
+            config.Profiles[targetProfile] = new ProfileConfig();
         }
 
-        var profile = config.Profiles[profileName];
+        var profile = config.Profiles[targetProfile];
 
         if (apiKey != null) profile.ApiKey = apiKey;
         if (domain != null) profile.Domain = domain;


### PR DESCRIPTION
## Summary
Adds a `--profile` flag to the `config set` command, allowing users to create and configure profiles without switching to them first.

## Changes
- Added `--profile/-p` option to `config set` command
- Updated `ConfigurationService.SetConfigAsync()` to accept optional profile parameter
- Profiles are created automatically if they don't exist
- Maintains backward compatibility (defaults to active profile when flag is omitted)
- Updated README documentation with usage examples

## Usage
```bash
# Create and configure a new profile without switching
pipedrive config set --profile staging --api-key STAGING_KEY --domain staging.pipedrive.com

# Update an existing profile
pipedrive config set --profile production --api-key PROD_KEY

# Still works without --profile (uses active profile)
pipedrive config set --api-key YOUR_KEY --domain company.pipedrive.com
```

## Testing
- ✅ Build succeeds with no errors
- ✅ Help text displays correctly
- ✅ Profile creation and configuration verified
- ✅ Backward compatibility maintained