### PR TITLE
Fix configuration setup instructions and add domain normalization

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -277,7 +277,7 @@ function Main {
         Write-Host "Installation complete! 🎉" -ForegroundColor Green
         Write-Host ""
         Write-Host "Run 'pipedrive --help' to get started" -ForegroundColor Cyan
-        Write-Host "Run 'pipedrive config set-api-token <token>' to configure" -ForegroundColor Cyan
+        Write-Host "Run 'pipedrive config set --api-key YOUR_API_KEY --domain company.pipedrive.com' to configure" -ForegroundColor Cyan
 
         # Create desktop shortcut option
         $createShortcut = Read-Host "`nCreate desktop shortcut? [y/N]"

--- a/install.sh
+++ b/install.sh
@@ -348,7 +348,7 @@ main() {
         echo "Installation complete! 🎉"
         echo ""
         echo "Run '${BINARY_NAME} --help' to get started"
-        echo "Run '${BINARY_NAME} config set-api-token <token>' to configure"
+        echo "Run '${BINARY_NAME} config set --api-key YOUR_API_KEY --domain company.pipedrive.com' to configure"
     fi
 }
 

--- a/src/PipedriveCLI.Tests/ConfigurationServiceTests.cs
+++ b/src/PipedriveCLI.Tests/ConfigurationServiceTests.cs
@@ -1,0 +1,35 @@
+using PipedriveCLI.Services;
+using Xunit;
+
+namespace PipedriveCLI.Tests;
+
+/// <summary>
+/// Tests for ConfigurationService, particularly domain normalization
+/// </summary>
+public class ConfigurationServiceTests
+{
+    [Theory]
+    [InlineData("company", "company.pipedrive.com")] // Simple company name
+    [InlineData("Company", "company.pipedrive.com")] // Case normalization
+    [InlineData("company.pipedrive.com", "company.pipedrive.com")] // Already qualified
+    [InlineData("https://company.pipedrive.com/", "company.pipedrive.com")] // Protocol + trailing slash
+    [InlineData("  company  ", "company.pipedrive.com")] // Whitespace trimming
+    public void NormalizeDomain_ShouldHandleVariousFormats(string input, string expected)
+    {
+        // Act
+        var result = ConfigurationService.NormalizeDomain(input);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void NormalizeDomain_ShouldHandleNull()
+    {
+        // Act
+        var result = ConfigurationService.NormalizeDomain(null!);
+
+        // Assert
+        Assert.Null(result);
+    }
+}

--- a/src/PipedriveCLI/Commands/ConfigCommands.cs
+++ b/src/PipedriveCLI/Commands/ConfigCommands.cs
@@ -30,15 +30,15 @@ public static class ConfigCommands
     /// </summary>
     private static Command CreateSetCommand(ConfigurationService configService)
     {
-        var setCommand = new Command("set", "Set configuration values");
+        var setCommand = new Command("set", "Set configuration values (both API key and domain are required for a working configuration)");
 
         var apiKeyOption = new Option<string?>(
             aliases: new[] { "--api-key", "-k" },
-            description: "Pipedrive API key");
+            description: "Pipedrive API key (required for API access)");
 
         var domainOption = new Option<string?>(
             aliases: new[] { "--domain", "-d" },
-            description: "Pipedrive domain (e.g., company.pipedrive.com)");
+            description: "Pipedrive domain - your company name, will auto-append .pipedrive.com if not present (e.g., 'company' or 'company.pipedrive.com')");
 
         var profileOption = new Option<string?>(
             aliases: new[] { "--profile", "-p" },
@@ -55,7 +55,8 @@ public static class ConfigCommands
                 if (string.IsNullOrWhiteSpace(apiKey) && string.IsNullOrWhiteSpace(domain))
                 {
                     AnsiConsole.MarkupLine("[red]Error:[/] At least one configuration value must be specified.");
-                    AnsiConsole.MarkupLine("Use [cyan]--api-key[/] or [cyan]--domain[/]");
+                    AnsiConsole.MarkupLine("Note: Both [cyan]--api-key[/] and [cyan]--domain[/] are required for a working configuration.");
+                    AnsiConsole.MarkupLine("Example: [dim]pipedrive config set --api-key YOUR_KEY --domain company[/]");
                     return;
                 }
 

--- a/src/PipedriveCLI/Services/ConfigurationService.cs
+++ b/src/PipedriveCLI/Services/ConfigurationService.cs
@@ -137,7 +137,7 @@ public sealed class ConfigurationService
             config.Profiles[profileName] = new ProfileConfig();
         }
 
-        config.Profiles[profileName].Domain = domain;
+        config.Profiles[profileName].Domain = NormalizeDomain(domain);
         await SaveConfigAsync(config);
     }
 
@@ -160,7 +160,7 @@ public sealed class ConfigurationService
         var profile = config.Profiles[targetProfile];
 
         if (apiKey != null) profile.ApiKey = apiKey;
-        if (domain != null) profile.Domain = domain;
+        if (domain != null) profile.Domain = NormalizeDomain(domain);
 
         await SaveConfigAsync(config);
     }
@@ -219,6 +219,44 @@ public sealed class ConfigurationService
     {
         var envValue = Environment.GetEnvironmentVariable(envVarName);
         return !string.IsNullOrWhiteSpace(envValue) ? envValue : configValue;
+    }
+
+    /// <summary>
+    /// Normalizes a Pipedrive domain by automatically appending .pipedrive.com if needed
+    /// </summary>
+    /// <param name="domain">The domain to normalize</param>
+    /// <returns>Normalized domain in the format company.pipedrive.com</returns>
+    internal static string NormalizeDomain(string domain)
+    {
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            return domain;
+        }
+
+        // Trim whitespace
+        domain = domain.Trim();
+
+        // Remove protocol if present (http://, https://)
+        if (domain.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+        {
+            domain = domain.Substring(7);
+        }
+        else if (domain.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            domain = domain.Substring(8);
+        }
+
+        // Remove trailing slashes
+        domain = domain.TrimEnd('/');
+
+        // If domain doesn't already end with .pipedrive.com, append it
+        if (!domain.EndsWith(".pipedrive.com", StringComparison.OrdinalIgnoreCase))
+        {
+            domain = $"{domain}.pipedrive.com";
+        }
+
+        // Convert to lowercase for consistency
+        return domain.ToLowerInvariant();
     }
 
     [System.Runtime.Versioning.SupportedOSPlatform("linux")]

--- a/src/PipedriveCLI/Services/PipedriveApiClient.cs
+++ b/src/PipedriveCLI/Services/PipedriveApiClient.cs
@@ -29,7 +29,7 @@ public sealed class PipedriveApiClient : IDisposable
         if (!profile.IsValid())
         {
             throw new InvalidOperationException(
-                "Pipedrive CLI is not configured. Run 'pipedrive config set --api-key <key> --domain <domain>' to configure.");
+                "Pipedrive CLI is not configured. Run 'pipedrive config set --api-key YOUR_API_KEY --domain company.pipedrive.com' to configure.");
         }
 
         // Set base address using the domain from config


### PR DESCRIPTION
## Summary

This PR addresses several configuration UX issues:

1. **Fixed incorrect post-install instructions** - Both `install.sh` and `install.ps1` referenced a non-existent `config set-api-token` command. Updated to show the correct `config set --api-key <key> --domain <domain>` syntax with example values.

2. **Added automatic domain normalization** - Users can now provide just their company name (e.g., `company`) and the system automatically appends `.pipedrive.com`. Also handles:
   - Protocol removal (`https://`, `http://`)
   - Trailing slash removal
   - Case normalization (converts to lowercase)
   - Preserves domains that already have `.pipedrive.com`

3. **Improved error messages** - Updated the "not configured" error in `PipedriveApiClient` to show a concrete example instead of placeholders.

4. **Clarified help text** - Updated `config set` command help to explicitly state that both `--api-key` and `--domain` are required for a working configuration, and explained automatic domain normalization.

5. **Added unit tests** - Comprehensive tests for domain normalization covering all edge cases.

## Testing

- All 66 existing tests pass
- 6 new unit tests added for domain normalization
- Build succeeds with no warnings

## User Impact

Users can now copy their company domain directly from Pipedrive settings without worrying about the format. These all work correctly:
- `company` → `company.pipedrive.com`
- `company.pipedrive.com` → `company.pipedrive.com`
- `https://company.pipedrive.com/` → `company.pipedrive.com`