### PR TITLE
Fix Markup.Escape bug in leads list and search display

### DIFF
--- a/src/PipedriveCLI/Commands/LeadsCommands.cs
+++ b/src/PipedriveCLI/Commands/LeadsCommands.cs
@@ -84,8 +84,8 @@ public static class LeadsCommands
                                     ?? "-";
 
                                 table.AddRow(
-                                    lead.Id ?? "-",
-                                    lead.Title ?? "-",
+                                    Markup.Escape(lead.Id ?? "-"),
+                                    Markup.Escape(lead.Title ?? "-"),
                                     valueDisplay,
                                     entityId,
                                     lead.OwnerId?.ToString() ?? "-",
@@ -483,8 +483,8 @@ public static class LeadsCommands
                             : "-";
 
                         table.AddRow(
-                            lead.Id ?? "-",
-                            lead.Title ?? "-",
+                            Markup.Escape(lead.Id ?? "-"),
+                            Markup.Escape(lead.Title ?? "-"),
                             valueDisplay,
                             lead.OwnerId?.ToString() ?? "-"
                         );


### PR DESCRIPTION
## Summary
- Fixed a bug where lead titles containing square brackets (e.g., `[Inquiry] Company Name`) were being interpreted as Spectre.Console markup
- This caused errors like: `Could not find color or style 'Inquiry'`
- Added `Markup.Escape()` calls to lead ID and title fields in both the `leads list` and `leads search` commands

## Problem
When listing leads via `pipedrive leads list`, any lead with a title containing square brackets would crash the CLI because Spectre.Console interprets `[text]` as markup for colors/styles.

## Solution
Wrapped user-provided strings (lead ID and title) with `Markup.Escape()` before adding them to the table, consistent with the fix applied in d5b9ec4 for custom field display.

## Test plan
- [x] Build passes
- [x] Tested `pipedrive leads list` with leads containing `[Inquiry]` in title - now displays correctly
- [x] Verified `pipedrive leads search` also properly escapes titles