### PR TITLE
Add --status filter to leads list command

### DIFF
--- a/src/PipedriveCLI/Commands/LeadsCommands.cs
+++ b/src/PipedriveCLI/Commands/LeadsCommands.cs
@@ -43,22 +43,40 @@ public static class LeadsCommands
             aliases: new[] { "--start", "-s" },
             description: "Pagination start (default: 0)");
 
+        var statusOption = new Option<string>(
+            aliases: new[] { "--status" },
+            description: "Filter by status: active, archived, or all (default: active)",
+            getDefaultValue: () => "active")
+            .FromAmong("active", "archived", "all");
+
         listCommand.AddOption(limitOption);
         listCommand.AddOption(startOption);
+        listCommand.AddOption(statusOption);
 
-        listCommand.SetHandler(async (limit, start) =>
+        listCommand.SetHandler(async (limit, start, status) =>
         {
             try
             {
                 await apiClient.InitializeAsync();
 
+                // Convert user-friendly status to API parameter
+                var archivedStatus = status switch
+                {
+                    "active" => "not_archived",
+                    "archived" => "archived",
+                    "all" => "all",
+                    _ => "not_archived"
+                };
+
+                var statusLabel = status == "active" ? "active " : (status == "archived" ? "archived " : "");
+
                 await AnsiConsole.Status()
-                    .StartAsync("Fetching leads...", async ctx =>
+                    .StartAsync($"Fetching {statusLabel}leads...", async ctx =>
                     {
                         ctx.Spinner(Spinner.Known.Dots);
                         ctx.SpinnerStyle(Style.Parse("green"));
 
-                        var response = await apiClient.GetLeadsAsync(limit, start);
+                        var response = await apiClient.GetLeadsAsync(limit, start, archivedStatus);
 
                         if (response?.Success == true && response.Data != null)
                         {
@@ -114,7 +132,7 @@ public static class LeadsCommands
             {
                 AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
             }
-        }, limitOption, startOption);
+        }, limitOption, startOption, statusOption);
 
         return listCommand;
     }

--- a/src/PipedriveCLI/Services/PipedriveApiClient.cs
+++ b/src/PipedriveCLI/Services/PipedriveApiClient.cs
@@ -126,11 +126,15 @@ public sealed class PipedriveApiClient : IDisposable
     /// <summary>
     /// Gets all leads
     /// </summary>
-    public async Task<PipedriveResponse<List<Lead>>?> GetLeadsAsync(int? limit = null, int? start = null)
+    /// <param name="limit">Number of leads to return</param>
+    /// <param name="start">Pagination start</param>
+    /// <param name="archivedStatus">Filter by archived status: "not_archived" (active only), "archived", or "all"</param>
+    public async Task<PipedriveResponse<List<Lead>>?> GetLeadsAsync(int? limit = null, int? start = null, string? archivedStatus = null)
     {
         var queryParams = new Dictionary<string, string>();
         if (limit.HasValue) queryParams["limit"] = limit.Value.ToString();
         if (start.HasValue) queryParams["start"] = start.Value.ToString();
+        if (!string.IsNullOrWhiteSpace(archivedStatus)) queryParams["archived_status"] = archivedStatus;
 
         var jsonResponse = await GetAsync("leads", queryParams);
         return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseListLead);


### PR DESCRIPTION
## Summary
Added a `--status` filter to the `leads list` command to filter leads by their archived status.

## New Feature
- **`--status active`** (default): Show only non-archived/active leads
- **`--status archived`**: Show only archived leads  
- **`--status all`**: Show all leads regardless of archived status

## Rationale
Previously, `pipedrive leads list` returned all leads including archived ones, which made it harder to see current active leads. Now the default behavior shows only active leads, which is more practical for daily CRM operations.

Users can still see archived leads when needed by explicitly using `--status archived` or `--status all`.

## Usage
```bash
# List active leads (default - no flag needed)
pipedrive leads list

# List archived leads
pipedrive leads list --status archived

# List all leads  
pipedrive leads list --status all
```

## Test plan
- [x] Build passes
- [x] `--status active` (default) returns only active leads
- [x] `--status archived` returns only archived leads
- [x] `--status all` returns all leads
- [x] Help text displays the new option correctly