### PR TITLE
Add email templates support

### DIFF
--- a/src/PipedriveCLI/Commands/TemplatesCommands.cs
+++ b/src/PipedriveCLI/Commands/TemplatesCommands.cs
@@ -1,0 +1,178 @@
+using System.CommandLine;
+using PipedriveCLI.Models;
+using PipedriveCLI.Services;
+using Spectre.Console;
+
+namespace PipedriveCLI.Commands;
+
+/// <summary>
+/// Commands for managing Pipedrive email templates
+/// </summary>
+public static class TemplatesCommands
+{
+    /// <summary>
+    /// Creates the root 'templates' command with all subcommands
+    /// </summary>
+    public static Command CreateTemplatesCommand(PipedriveApiClient apiClient)
+    {
+        var templatesCommand = new Command("templates", "Manage Pipedrive email templates");
+
+        // Add subcommands
+        templatesCommand.AddCommand(CreateListCommand(apiClient));
+        templatesCommand.AddCommand(CreateGetCommand(apiClient));
+
+        return templatesCommand;
+    }
+
+    /// <summary>
+    /// Creates the 'templates list' command
+    /// </summary>
+    private static Command CreateListCommand(PipedriveApiClient apiClient)
+    {
+        var listCommand = new Command("list", "List all email templates");
+
+        listCommand.SetHandler(async () =>
+        {
+            try
+            {
+                await apiClient.InitializeAsync();
+
+                await AnsiConsole.Status()
+                    .StartAsync("Fetching email templates...", async ctx =>
+                    {
+                        ctx.Spinner(Spinner.Known.Dots);
+                        ctx.SpinnerStyle(Style.Parse("green"));
+
+                        var response = await apiClient.GetEmailTemplatesAsync();
+
+                        if (response?.Success == true && response.Data != null)
+                        {
+                            ctx.Status("Formatting results...");
+
+                            var table = new Table();
+                            table.Border(TableBorder.Rounded);
+                            table.AddColumn("ID");
+                            table.AddColumn("Name");
+                            table.AddColumn("Shared");
+                            table.AddColumn("Updated");
+
+                            foreach (var template in response.Data)
+                            {
+                                var sharedDisplay = template.SharedFlag == 1 ? "Yes" : "No";
+
+                                table.AddRow(
+                                    template.Id.ToString(),
+                                    Markup.Escape(template.Name ?? "-"),
+                                    sharedDisplay,
+                                    template.UpdateTime ?? "-"
+                                );
+                            }
+
+                            AnsiConsole.Write(table);
+                            AnsiConsole.MarkupLine($"\n[green]✓[/] Found {response.Data.Count} template(s)");
+                        }
+                        else
+                        {
+                            AnsiConsole.MarkupLine($"[red]✗[/] Failed to fetch templates: {Markup.Escape(response?.Error ?? "Unknown error")}");
+                        }
+                    });
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
+            }
+        });
+
+        return listCommand;
+    }
+
+    /// <summary>
+    /// Creates the 'templates get' command
+    /// </summary>
+    private static Command CreateGetCommand(PipedriveApiClient apiClient)
+    {
+        var getCommand = new Command("get", "Get a specific email template by ID");
+
+        var idArgument = new Argument<int>("id", "Template ID");
+        getCommand.AddArgument(idArgument);
+
+        var showContentOption = new Option<bool>(
+            aliases: new[] { "--content", "-c" },
+            description: "Show the full HTML content of the template");
+
+        getCommand.AddOption(showContentOption);
+
+        getCommand.SetHandler(async (id, showContent) =>
+        {
+            try
+            {
+                await apiClient.InitializeAsync();
+
+                var response = await AnsiConsole.Status()
+                    .StartAsync($"Fetching template {id}...", async ctx =>
+                    {
+                        ctx.Spinner(Spinner.Known.Dots);
+                        ctx.SpinnerStyle(Style.Parse("green"));
+                        return await apiClient.GetEmailTemplateByIdAsync(id);
+                    });
+
+                if (response?.Success == true && response.Data != null)
+                {
+                    var template = response.Data;
+
+                    var panel = new Panel(new Markup(
+                        $"[bold]Name:[/] {Markup.Escape(template.Name ?? "")}\n" +
+                        $"[bold]ID:[/] {template.Id}\n" +
+                        $"[bold]Subject:[/] {Markup.Escape(template.Subject ?? "N/A")}\n" +
+                        $"[bold]Shared:[/] {(template.SharedFlag == 1 ? "Yes" : "No")}\n" +
+                        $"[bold]User ID:[/] {template.UserId?.ToString() ?? "N/A"}\n" +
+                        $"[bold]Added:[/] {template.AddTime ?? "N/A"}\n" +
+                        $"[bold]Updated:[/] {template.UpdateTime ?? "N/A"}"))
+                    {
+                        Header = new PanelHeader($"[green]Template: {Markup.Escape(template.Name ?? "")}[/]"),
+                        Border = BoxBorder.Rounded
+                    };
+
+                    AnsiConsole.Write(panel);
+
+                    if (showContent && !string.IsNullOrWhiteSpace(template.Content))
+                    {
+                        AnsiConsole.WriteLine();
+                        AnsiConsole.Write(new Rule("[yellow]Content (HTML)[/]"));
+                        AnsiConsole.WriteLine();
+
+                        // Strip HTML tags for display, or show raw HTML
+                        var content = template.Content;
+                        // Simple HTML tag stripping for readable display
+                        var plainText = System.Text.RegularExpressions.Regex.Replace(content, "<[^>]+>", "");
+                        plainText = System.Net.WebUtility.HtmlDecode(plainText);
+                        plainText = System.Text.RegularExpressions.Regex.Replace(plainText, @"\s+", " ").Trim();
+
+                        AnsiConsole.Write(new Panel(Markup.Escape(plainText))
+                        {
+                            Header = new PanelHeader("[dim]Plain text preview[/]"),
+                            Border = BoxBorder.Rounded
+                        });
+
+                        AnsiConsole.WriteLine();
+                        AnsiConsole.MarkupLine("[dim]Use --content to see content. Raw HTML is available in the API response.[/]");
+                    }
+                    else if (!showContent)
+                    {
+                        AnsiConsole.MarkupLine("\n[dim]Tip: Use --content or -c to see the template content[/]");
+                    }
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine($"[red]✗[/] Failed to fetch template: {Markup.Escape(response?.Error ?? "Unknown error")}");
+                }
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
+            }
+        }, idArgument, showContentOption);
+
+        return getCommand;
+    }
+}

--- a/src/PipedriveCLI/Models/ApiModels.cs
+++ b/src/PipedriveCLI/Models/ApiModels.cs
@@ -623,6 +623,48 @@ public sealed class Note
 }
 
 /// <summary>
+/// Pipedrive Email Template model
+/// </summary>
+public sealed class EmailTemplate
+{
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("subject")]
+    public string? Subject { get; set; }
+
+    [JsonPropertyName("content")]
+    public string? Content { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public int? UserId { get; set; }
+
+    [JsonPropertyName("add_time")]
+    public string? AddTime { get; set; }
+
+    [JsonPropertyName("update_time")]
+    public string? UpdateTime { get; set; }
+
+    [JsonPropertyName("shared_flag")]
+    public int? SharedFlag { get; set; }
+
+    [JsonPropertyName("deleted_flag")]
+    public int? DeletedFlag { get; set; }
+
+    [JsonPropertyName("visible_flag")]
+    public int? VisibleFlag { get; set; }
+
+    [JsonPropertyName("order_nr")]
+    public int? OrderNr { get; set; }
+
+    [JsonPropertyName("has_real_attachments_flag")]
+    public bool? HasRealAttachmentsFlag { get; set; }
+}
+
+/// <summary>
 /// Field definition option for select/multi-select fields
 /// </summary>
 public sealed class FieldOption
@@ -738,6 +780,10 @@ public sealed class OrganizationField : BaseField
 [JsonSerializable(typeof(PipedriveResponse<Stage>))]
 [JsonSerializable(typeof(PipedriveResponse<List<Pipeline>>))]
 [JsonSerializable(typeof(PipedriveResponse<List<Stage>>))]
+[JsonSerializable(typeof(EmailTemplate))]
+[JsonSerializable(typeof(List<EmailTemplate>))]
+[JsonSerializable(typeof(PipedriveResponse<EmailTemplate>))]
+[JsonSerializable(typeof(PipedriveResponse<List<EmailTemplate>>))]
 internal partial class ApiJsonContext : JsonSerializerContext
 {
 }

--- a/src/PipedriveCLI/Program.cs
+++ b/src/PipedriveCLI/Program.cs
@@ -59,6 +59,9 @@ public static class Program
         // Add pipelines command
         rootCommand.AddCommand(PipelinesCommands.CreatePipelinesCommand(apiClient));
 
+        // Add email templates command
+        rootCommand.AddCommand(TemplatesCommands.CreateTemplatesCommand(apiClient));
+
         // Add update command
         rootCommand.AddCommand(UpdateCommands.CreateUpdateCommand());
 

--- a/src/PipedriveCLI/Services/PipedriveApiClient.cs
+++ b/src/PipedriveCLI/Services/PipedriveApiClient.cs
@@ -654,6 +654,28 @@ public sealed class PipedriveApiClient : IDisposable
 
     #endregion
 
+    #region Email Templates Operations
+
+    /// <summary>
+    /// Gets all email templates
+    /// </summary>
+    public async Task<PipedriveResponse<List<EmailTemplate>>?> GetEmailTemplatesAsync()
+    {
+        var jsonResponse = await GetAsync("mailbox/mailTemplates");
+        return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseListEmailTemplate);
+    }
+
+    /// <summary>
+    /// Gets a specific email template by ID
+    /// </summary>
+    public async Task<PipedriveResponse<EmailTemplate>?> GetEmailTemplateByIdAsync(int id)
+    {
+        var jsonResponse = await GetAsync($"mailbox/mailTemplates/{id}");
+        return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseEmailTemplate);
+    }
+
+    #endregion
+
     /// <summary>
     /// Tests the API connection by making a simple request
     /// </summary>


### PR DESCRIPTION
## Summary
Added support for viewing Pipedrive email templates via the CLI.

## New Commands

### `pipedrive templates list`
List all email templates with their ID, name, shared status, and last update time.

```bash
$ pipedrive templates list
╭─────┬────────────────────────────────────┬────────┬──────────────────────────╮
│ ID  │ Name                               │ Shared │ Updated                  │
├─────┼────────────────────────────────────┼────────┼──────────────────────────┤
│ 116 │ Phobos: 1st Renewal Reminder       │ Yes    │ 2025-01-16T14:02:56.000Z │
│ 117 │ Phobos: Expired or Cancelled...    │ Yes    │ 2025-01-13T13:56:39.000Z │
...
```

### `pipedrive templates get <id>`
Get a specific template by ID with full details including subject line.

```bash
$ pipedrive templates get 116
╭─Template: Phobos: 1st Renewal Reminder───────────────────────────────────────╮
│ Name: Phobos: 1st Renewal Reminder                                           │
│ ID: 116                                                                      │
│ Subject: [Organization]'s Phobos Subscription Expires on...                  │
│ Shared: Yes                                                                  │
│ User ID: 10204689                                                            │
│ Added: 2025-01-10T13:51:36.000Z                                              │
│ Updated: 2025-01-16T14:02:56.000Z                                            │
╰──────────────────────────────────────────────────────────────────────────────╯
```

### `pipedrive templates get <id> --content`
Show the template with a plain text preview of the HTML content.

## Implementation Details
- Added `EmailTemplate` model to `ApiModels.cs`
- Added API client methods: `GetEmailTemplatesAsync()` and `GetEmailTemplateByIdAsync(int id)`
- Created `TemplatesCommands.cs` with list and get subcommands
- Registered the templates command in `Program.cs`
- Used `Markup.Escape()` for template names to handle special characters like `[Phobos]`

## Test Plan
- [x] Build passes
- [x] `pipedrive templates list` shows all templates
- [x] `pipedrive templates get <id>` shows template details
- [x] `pipedrive templates get <id> --content` shows plain text preview
- [x] Template names with brackets (e.g., `[Phobos]`) display correctly