### PR TITLE
Add cc_email (Smart BCC) field support for all entity types

### DIFF
--- a/src/PipedriveCLI.Tests/CcEmailDeserializationTests.cs
+++ b/src/PipedriveCLI.Tests/CcEmailDeserializationTests.cs
@@ -1,0 +1,376 @@
+using System.Text.Json;
+using PipedriveCLI.Models;
+using Xunit;
+
+namespace PipedriveCLI.Tests;
+
+/// <summary>
+/// Tests for cc_email (Smart BCC) field deserialization across all entity types
+/// </summary>
+public class CcEmailDeserializationTests
+{
+    /// <summary>
+    /// Test Lead deserialization with cc_email field
+    /// </summary>
+    [Fact]
+    public void Lead_Deserialization_HandlesCcEmail()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "id": "abc-123-def",
+                "title": "New Lead",
+                "person_id": 456,
+                "organization_id": 789,
+                "owner_id": 1,
+                "value": {
+                    "amount": 5000.00,
+                    "currency": "USD"
+                },
+                "expected_close_date": "2024-12-31",
+                "was_seen": true,
+                "cc_email": "petabridgellc-baa75d+lead123@pipedrivemail.com",
+                "add_time": "2024-01-15T10:30:00Z",
+                "update_time": "2024-01-16T14:20:00Z"
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseLead);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Equal("abc-123-def", response.Data.Id);
+        Assert.Equal("New Lead", response.Data.Title);
+        Assert.Equal("petabridgellc-baa75d+lead123@pipedrivemail.com", response.Data.CcEmail);
+    }
+
+    /// <summary>
+    /// Test Lead deserialization with null cc_email
+    /// </summary>
+    [Fact]
+    public void Lead_Deserialization_HandlesNullCcEmail()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "id": "abc-123-def",
+                "title": "Lead Without CC",
+                "person_id": 456,
+                "cc_email": null,
+                "add_time": "2024-01-15T10:30:00Z",
+                "update_time": "2024-01-16T14:20:00Z"
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseLead);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Null(response.Data.CcEmail);
+    }
+
+    /// <summary>
+    /// Test Person deserialization with cc_email field
+    /// </summary>
+    [Fact]
+    public void Person_Deserialization_HandlesCcEmail()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "id": 123,
+                "name": "John Doe",
+                "first_name": "John",
+                "last_name": "Doe",
+                "email": [
+                    {
+                        "value": "john@example.com",
+                        "primary": true,
+                        "label": "work"
+                    }
+                ],
+                "phone": [],
+                "org_id": null,
+                "cc_email": "petabridgellc-baa75d+person123@pipedrivemail.com",
+                "add_time": "2024-01-15T10:30:00Z",
+                "update_time": "2024-01-16T14:20:00Z"
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponsePerson);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Equal(123, response.Data.Id);
+        Assert.Equal("John Doe", response.Data.Name);
+        Assert.Equal("petabridgellc-baa75d+person123@pipedrivemail.com", response.Data.CcEmail);
+    }
+
+    /// <summary>
+    /// Test Person deserialization with null cc_email
+    /// </summary>
+    [Fact]
+    public void Person_Deserialization_HandlesNullCcEmail()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "id": 124,
+                "name": "Jane Doe",
+                "cc_email": null,
+                "add_time": "2024-01-15T10:30:00Z",
+                "update_time": "2024-01-16T14:20:00Z"
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponsePerson);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Null(response.Data.CcEmail);
+    }
+
+    /// <summary>
+    /// Test Organization deserialization with cc_email field
+    /// </summary>
+    [Fact]
+    public void Organization_Deserialization_HandlesCcEmail()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "id": 789,
+                "name": "Acme Corp",
+                "people_count": 5,
+                "address": "123 Main St, City, State 12345",
+                "cc_email": "petabridgellc-baa75d+org789@pipedrivemail.com",
+                "add_time": "2024-01-15T10:30:00Z",
+                "update_time": "2024-01-16T14:20:00Z"
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseOrganization);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Equal(789, response.Data.Id);
+        Assert.Equal("Acme Corp", response.Data.Name);
+        Assert.Equal("petabridgellc-baa75d+org789@pipedrivemail.com", response.Data.CcEmail);
+    }
+
+    /// <summary>
+    /// Test Organization deserialization with null cc_email
+    /// </summary>
+    [Fact]
+    public void Organization_Deserialization_HandlesNullCcEmail()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "id": 790,
+                "name": "Widget Inc",
+                "people_count": 10,
+                "cc_email": null,
+                "add_time": "2024-01-15T10:30:00Z",
+                "update_time": "2024-01-16T14:20:00Z"
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseOrganization);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Null(response.Data.CcEmail);
+    }
+
+    /// <summary>
+    /// Test Activity deserialization with cc_email field
+    /// </summary>
+    [Fact]
+    public void Activity_Deserialization_HandlesCcEmail()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "id": 456,
+                "subject": "Follow up call",
+                "type": "call",
+                "due_date": "2024-12-31",
+                "due_time": "14:00",
+                "done": false,
+                "deal_id": 100,
+                "person_id": 200,
+                "org_id": 300,
+                "note": "Discuss contract terms",
+                "user_id": 1,
+                "cc_email": "petabridgellc-baa75d+activity456@pipedrivemail.com",
+                "add_time": "2024-01-15T10:30:00Z",
+                "update_time": "2024-01-16T14:20:00Z"
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseActivity);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Equal(456, response.Data.Id);
+        Assert.Equal("Follow up call", response.Data.Subject);
+        Assert.Equal("petabridgellc-baa75d+activity456@pipedrivemail.com", response.Data.CcEmail);
+    }
+
+    /// <summary>
+    /// Test Activity deserialization with null cc_email
+    /// </summary>
+    [Fact]
+    public void Activity_Deserialization_HandlesNullCcEmail()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "id": 457,
+                "subject": "Meeting",
+                "type": "meeting",
+                "due_date": "2024-12-31",
+                "done": false,
+                "cc_email": null,
+                "add_time": "2024-01-15T10:30:00Z",
+                "update_time": "2024-01-16T14:20:00Z"
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseActivity);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Null(response.Data.CcEmail);
+    }
+
+    /// <summary>
+    /// Test that missing cc_email field doesn't cause deserialization errors
+    /// </summary>
+    [Fact]
+    public void AllEntities_Deserialization_HandlesMissingCcEmail()
+    {
+        // Test Deal without cc_email
+        var dealJson = """
+        {
+            "success": true,
+            "data": {
+                "id": 1,
+                "title": "Test",
+                "value": 0,
+                "status": "open"
+            }
+        }
+        """;
+        var dealResponse = JsonSerializer.Deserialize(dealJson, ApiJsonContext.Default.PipedriveResponseDeal);
+        Assert.NotNull(dealResponse?.Data);
+        Assert.Null(dealResponse.Data.CcEmail);
+
+        // Test Lead without cc_email
+        var leadJson = """
+        {
+            "success": true,
+            "data": {
+                "id": "abc",
+                "title": "Test Lead"
+            }
+        }
+        """;
+        var leadResponse = JsonSerializer.Deserialize(leadJson, ApiJsonContext.Default.PipedriveResponseLead);
+        Assert.NotNull(leadResponse?.Data);
+        Assert.Null(leadResponse.Data.CcEmail);
+
+        // Test Person without cc_email
+        var personJson = """
+        {
+            "success": true,
+            "data": {
+                "id": 1,
+                "name": "Test Person"
+            }
+        }
+        """;
+        var personResponse = JsonSerializer.Deserialize(personJson, ApiJsonContext.Default.PipedriveResponsePerson);
+        Assert.NotNull(personResponse?.Data);
+        Assert.Null(personResponse.Data.CcEmail);
+
+        // Test Organization without cc_email
+        var orgJson = """
+        {
+            "success": true,
+            "data": {
+                "id": 1,
+                "name": "Test Org",
+                "people_count": 0
+            }
+        }
+        """;
+        var orgResponse = JsonSerializer.Deserialize(orgJson, ApiJsonContext.Default.PipedriveResponseOrganization);
+        Assert.NotNull(orgResponse?.Data);
+        Assert.Null(orgResponse.Data.CcEmail);
+
+        // Test Activity without cc_email
+        var activityJson = """
+        {
+            "success": true,
+            "data": {
+                "id": 1,
+                "subject": "Test Activity",
+                "done": false
+            }
+        }
+        """;
+        var activityResponse = JsonSerializer.Deserialize(activityJson, ApiJsonContext.Default.PipedriveResponseActivity);
+        Assert.NotNull(activityResponse?.Data);
+        Assert.Null(activityResponse.Data.CcEmail);
+    }
+}

--- a/src/PipedriveCLI.Tests/DealsApiClientTests.cs
+++ b/src/PipedriveCLI.Tests/DealsApiClientTests.cs
@@ -444,4 +444,112 @@ public class DealsApiClientTests
         Assert.Null(response.Data.PersonId);
         Assert.Null(response.Data.OrgId);
     }
+
+    /// <summary>
+    /// Test that Deal deserialization correctly handles the cc_email field (Smart BCC)
+    /// </summary>
+    [Fact]
+    public void Deal_Deserialization_HandlesCcEmail()
+    {
+        // Arrange - Full API response with cc_email field
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "id": 835,
+                "title": "Enterprise Deal with Email",
+                "value": 50000.00,
+                "currency": "USD",
+                "person_id": 456,
+                "org_id": 789,
+                "stage_id": 1,
+                "status": "open",
+                "probability": 75.5,
+                "expected_close_date": "2024-12-31",
+                "cc_email": "petabridgellc-baa75d+deal835@pipedrivemail.com",
+                "add_time": "2024-01-15T10:30:00Z",
+                "update_time": "2024-01-16T14:20:00Z"
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseDeal);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Equal(835, response.Data.Id);
+        Assert.Equal("Enterprise Deal with Email", response.Data.Title);
+        Assert.Equal("petabridgellc-baa75d+deal835@pipedrivemail.com", response.Data.CcEmail);
+    }
+
+    /// <summary>
+    /// Test that Deal deserialization handles null cc_email field
+    /// </summary>
+    [Fact]
+    public void Deal_Deserialization_HandlesNullCcEmail()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "id": 500,
+                "title": "Deal Without CC Email",
+                "value": 0,
+                "currency": "USD",
+                "person_id": null,
+                "org_id": null,
+                "stage_id": null,
+                "status": "open",
+                "cc_email": null,
+                "add_time": "2024-01-01T00:00:00Z",
+                "update_time": "2024-01-01T00:00:00Z"
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseDeal);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Null(response.Data.CcEmail);
+    }
+
+    /// <summary>
+    /// Test that Deal deserialization handles missing cc_email field
+    /// </summary>
+    [Fact]
+    public void Deal_Deserialization_HandlesMissingCcEmail()
+    {
+        // Arrange - API response without cc_email field at all
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "id": 501,
+                "title": "Deal Without CC Email Field",
+                "value": 1000,
+                "currency": "USD",
+                "status": "open",
+                "add_time": "2024-01-01T00:00:00Z",
+                "update_time": "2024-01-01T00:00:00Z"
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseDeal);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Null(response.Data.CcEmail);
+    }
 }

--- a/src/PipedriveCLI/Commands/ActivitiesCommands.cs
+++ b/src/PipedriveCLI/Commands/ActivitiesCommands.cs
@@ -172,6 +172,7 @@ public static class ActivitiesCommands
                         $"[bold]Person ID:[/] {activity.PersonId?.ToString() ?? "N/A"}\n" +
                         $"[bold]Organization ID:[/] {activity.OrgId?.ToString() ?? "N/A"}\n" +
                         $"[bold]Note:[/] {activity.Note ?? "N/A"}\n" +
+                        $"[bold]CC Email:[/] {Markup.Escape(activity.CcEmail ?? "N/A")}\n" +
                         $"[bold]Added:[/] {activity.AddTime}\n" +
                         $"[bold]Updated:[/] {activity.UpdateTime}"))
                     {

--- a/src/PipedriveCLI/Commands/DealsCommands.cs
+++ b/src/PipedriveCLI/Commands/DealsCommands.cs
@@ -204,6 +204,7 @@ public static class DealsCommands
                             $"[bold]Organization ID:[/] {deal.OrgId?.ToString() ?? "N/A"}\n" +
                             $"[bold]Probability:[/] {(deal.Probability.HasValue ? $"{deal.Probability.Value}%" : "N/A")}\n" +
                             $"[bold]Expected Close Date:[/] {Markup.Escape(deal.ExpectedCloseDate ?? "N/A")}\n" +
+                            $"[bold]CC Email:[/] {Markup.Escape(deal.CcEmail ?? "N/A")}\n" +
                             $"[bold]Added:[/] {Markup.Escape(deal.AddTime ?? "N/A")}\n" +
                             $"[bold]Updated:[/] {Markup.Escape(deal.UpdateTime ?? "N/A")}" +
                             customFieldsDisplay))

--- a/src/PipedriveCLI/Commands/LeadsCommands.cs
+++ b/src/PipedriveCLI/Commands/LeadsCommands.cs
@@ -173,6 +173,7 @@ public static class LeadsCommands
                         $"[bold]Owner ID:[/] {lead.OwnerId?.ToString() ?? "N/A"}\n" +
                         $"[bold]Value:[/] {(lead.Value != null ? $"{lead.Value.Currency} {lead.Value.Amount:N2}" : "N/A")}\n" +
                         $"[bold]Expected Close Date:[/] {lead.ExpectedCloseDate ?? "N/A"}\n" +
+                        $"[bold]CC Email:[/] {Markup.Escape(lead.CcEmail ?? "N/A")}\n" +
                         $"[bold]Was Seen:[/] {lead.WasSeen}\n" +
                         $"[bold]Added:[/] {lead.AddTime}\n" +
                         $"[bold]Updated:[/] {lead.UpdateTime}"))

--- a/src/PipedriveCLI/Commands/OrganizationsCommands.cs
+++ b/src/PipedriveCLI/Commands/OrganizationsCommands.cs
@@ -167,6 +167,7 @@ public static class OrganizationsCommands
                             $"[bold]People Count:[/] {org.PeopleCount}\n" +
                             $"[bold]Address:[/] {Markup.Escape(org.Address ?? "N/A")}\n" +
                             $"[bold]Owner:[/] {Markup.Escape(ownerInfo)}\n" +
+                            $"[bold]CC Email:[/] {Markup.Escape(org.CcEmail ?? "N/A")}\n" +
                             $"[bold]Added:[/] {Markup.Escape(org.AddTime ?? "N/A")}\n" +
                             $"[bold]Updated:[/] {Markup.Escape(org.UpdateTime ?? "N/A")}" +
                             customFieldsDisplay))

--- a/src/PipedriveCLI/Commands/PersonsCommands.cs
+++ b/src/PipedriveCLI/Commands/PersonsCommands.cs
@@ -174,6 +174,7 @@ public static class PersonsCommands
                         $"[bold]Phone(s):[/] {Markup.Escape(phones)}\n" +
                         $"[bold]Organization ID:[/] {person.OrgId?.ToString() ?? "N/A"}\n" +
                         $"[bold]Owner:[/] {Markup.Escape(ownerInfo)}\n" +
+                        $"[bold]CC Email:[/] {Markup.Escape(person.CcEmail ?? "N/A")}\n" +
                         $"[bold]Added:[/] {Markup.Escape(person.AddTime ?? "N/A")}\n" +
                         $"[bold]Updated:[/] {Markup.Escape(person.UpdateTime ?? "N/A")}" +
                         customFieldsDisplay))

--- a/src/PipedriveCLI/Models/ApiModels.cs
+++ b/src/PipedriveCLI/Models/ApiModels.cs
@@ -160,6 +160,9 @@ public sealed class Lead
 
     [JsonPropertyName("update_time")]
     public string? UpdateTime { get; set; }
+
+    [JsonPropertyName("cc_email")]
+    public string? CcEmail { get; set; }
 }
 
 /// <summary>
@@ -314,6 +317,9 @@ public sealed class Deal
     [JsonPropertyName("expected_close_date")]
     public string? ExpectedCloseDate { get; set; }
 
+    [JsonPropertyName("cc_email")]
+    public string? CcEmail { get; set; }
+
     /// <summary>
     /// Custom fields - captured as extension data with hash keys
     /// </summary>
@@ -356,6 +362,9 @@ public sealed class Person
 
     [JsonPropertyName("update_time")]
     public string? UpdateTime { get; set; }
+
+    [JsonPropertyName("cc_email")]
+    public string? CcEmail { get; set; }
 
     /// <summary>
     /// Custom fields - captured as extension data with hash keys
@@ -438,6 +447,9 @@ public sealed class Organization
     [JsonPropertyName("update_time")]
     public string? UpdateTime { get; set; }
 
+    [JsonPropertyName("cc_email")]
+    public string? CcEmail { get; set; }
+
     /// <summary>
     /// Custom fields - captured as extension data with hash keys
     /// </summary>
@@ -491,6 +503,9 @@ public sealed class Activity
 
     [JsonPropertyName("update_time")]
     public string? UpdateTime { get; set; }
+
+    [JsonPropertyName("cc_email")]
+    public string? CcEmail { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary
Display the cc_email field in formatted output for deals, leads, persons, organizations, and activities. This enables LLM agents and users to easily access the Smart BCC address for automatic email sync to Pipedrive.

## Changes
- Added `CcEmail` property with `[JsonPropertyName("cc_email")]` to 5 model classes: Deal, Lead, Person, Organization, Activity
- Updated panel output in 5 command files to display CC Email field
- Added 12 new tests for cc_email deserialization across all entity types

## Test plan
- [x] All 87 unit tests passing (12 new cc_email tests)
- [x] Verified CC Email displays for leads: `pipedrive leads get <id>`
- [x] Verified CC Email displays for deals: `pipedrive deals get <id>`

Fixes #50