### PR TITLE
Add emails command for viewing email history on deals, persons, and threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A fast, lightweight command-line interface for managing your Pipedrive CRM. Buil
   - [activities - Activities Management](#activities---activities-management)
   - [notes - Notes Management](#notes---notes-management)
   - [pipelines - Pipelines Management](#pipelines---pipelines-management)
+  - [emails - Email History](#emails---email-history)
   - [update - Auto-Update](#update---auto-update)
 - [Getting Your API Key](#getting-your-api-key)
 - [Building from Source](#building-from-source)
@@ -39,6 +40,7 @@ A fast, lightweight command-line interface for managing your Pipedrive CRM. Buil
 - **🎨 Beautiful Console UI** - Rich formatting with Spectre.Console
 - **🔄 Multi-Profile Support** - Manage multiple Pipedrive environments (dev, staging, prod)
 - **📝 Full CRM Management** - Complete CRUD operations for leads, deals, persons, organizations, activities, and notes
+- **📧 Email History** - View email conversations and threads for deals and contacts
 - **🔀 Entity Merging** - Merge duplicate persons, deals, and organizations with confirmation prompts
 - **🏷️ Custom Fields** - View custom fields with friendly names and update them via CLI
 - **🔧 Pipeline Management** - View pipelines and stages to understand your sales process
@@ -513,6 +515,48 @@ Example output for `pipelines stages 1`:
 │ 3    │ Demo Scheduled   │ 15        │ 40%          │
 │ 4    │ Proposal Made    │ 10        │ 80%          │
 ╰──────┴──────────────────┴───────────┴──────────────╯
+```
+
+### `emails` - Email History
+
+View email conversations and threads associated with deals and contacts. Essential for LLM agents and humans to understand prior context before reaching out.
+
+```bash
+# List emails for a deal
+pipedrive emails list-for-deal <deal-id> [--limit 50] [--start 0]
+
+# List emails for a person
+pipedrive emails list-for-person <person-id> [--limit 50] [--start 0]
+
+# Get a specific email message
+pipedrive emails get <message-id>
+
+# Get email with full body content
+pipedrive emails get <message-id> --include-body
+
+# List mail threads by folder
+pipedrive emails threads [--folder inbox|sent|drafts|archive] [--limit 50] [--start 0]
+
+# Get a specific mail thread
+pipedrive emails thread <thread-id>
+
+# Get all messages in a thread
+pipedrive emails thread-messages <thread-id>
+
+# Get all messages in a thread with full body content
+pipedrive emails thread-messages <thread-id> --include-body
+```
+
+Example workflow for understanding deal history:
+```bash
+# 1. See that a deal has 9 emails
+pipedrive deals get 835
+
+# 2. List all emails for that deal
+pipedrive emails list-for-deal 835
+
+# 3. Read a specific email's full content
+pipedrive emails get 12345 --include-body
 ```
 
 ### `update` - Auto-Update

--- a/src/PipedriveCLI.Tests/MailMessagesApiClientTests.cs
+++ b/src/PipedriveCLI.Tests/MailMessagesApiClientTests.cs
@@ -1,0 +1,838 @@
+using System.Text.Json;
+using PipedriveCLI.Models;
+using Xunit;
+
+namespace PipedriveCLI.Tests;
+
+/// <summary>
+/// Tests for Mail Messages and Mail Threads API serialization
+/// </summary>
+public class MailMessagesApiClientTests
+{
+    #region MailParty Tests
+
+    /// <summary>
+    /// Test that MailParty deserialization handles all fields correctly
+    /// </summary>
+    [Fact]
+    public void MailParty_Deserialization_AllFields()
+    {
+        // Arrange
+        var json = """
+        {
+            "id": 123,
+            "email_address": "john@example.com",
+            "name": "John Doe",
+            "linked_person_id": 456,
+            "linked_person_name": "John D.",
+            "linked_organization_id": 789,
+            "mail_message_party_id": 101112,
+            "latest_sent": true,
+            "message_time": 1699999999
+        }
+        """;
+
+        // Act
+        var party = JsonSerializer.Deserialize(json, ApiJsonContext.Default.MailParty);
+
+        // Assert
+        Assert.NotNull(party);
+        Assert.Equal(123, party.Id);
+        Assert.Equal("john@example.com", party.EmailAddress);
+        Assert.Equal("John Doe", party.Name);
+        Assert.Equal(456, party.LinkedPersonId);
+        Assert.Equal("John D.", party.LinkedPersonName);
+        Assert.Equal(789, party.LinkedOrganizationId);
+        Assert.Equal(101112, party.MailMessagePartyId);
+        Assert.True(party.LatestSent);
+    }
+
+    /// <summary>
+    /// Test that MailParty handles minimal fields
+    /// </summary>
+    [Fact]
+    public void MailParty_Deserialization_MinimalFields()
+    {
+        // Arrange
+        var json = """
+        {
+            "id": 100,
+            "email_address": "minimal@test.com",
+            "name": null
+        }
+        """;
+
+        // Act
+        var party = JsonSerializer.Deserialize(json, ApiJsonContext.Default.MailParty);
+
+        // Assert
+        Assert.NotNull(party);
+        Assert.Equal(100, party.Id);
+        Assert.Equal("minimal@test.com", party.EmailAddress);
+        Assert.Null(party.Name);
+        Assert.Null(party.LinkedPersonId);
+    }
+
+    #endregion
+
+    #region MailMessage Tests
+
+    /// <summary>
+    /// Test that MailMessage deserialization handles full API response
+    /// </summary>
+    [Fact]
+    public void MailMessage_Deserialization_FullApiResponse()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "id": 12345,
+                "from": [
+                    {
+                        "id": 1,
+                        "email_address": "sender@company.com",
+                        "name": "Sales Rep",
+                        "linked_person_id": 100,
+                        "linked_person_name": "Sales Representative"
+                    }
+                ],
+                "to": [
+                    {
+                        "id": 2,
+                        "email_address": "prospect@customer.com",
+                        "name": "John Customer",
+                        "linked_person_id": 200,
+                        "linked_person_name": "John Customer"
+                    }
+                ],
+                "cc": [
+                    {
+                        "id": 3,
+                        "email_address": "manager@company.com",
+                        "name": "Manager"
+                    }
+                ],
+                "bcc": [],
+                "subject": "Follow-up on our discussion",
+                "snippet": "Hi John, I wanted to follow up on our conversation yesterday...",
+                "body": "<html><body><p>Hi John, I wanted to follow up on our conversation yesterday...</p></body></html>",
+                "body_url": "https://api.pipedrive.com/v1/mailbox/mailMessages/12345/body",
+                "account_id": "abc123",
+                "user_id": 555,
+                "mail_thread_id": 999,
+                "mail_tracking_status": "opened",
+                "mail_link_tracking_enabled_flag": 1,
+                "read_flag": 1,
+                "draft_flag": 0,
+                "synced_flag": 1,
+                "deleted_flag": 0,
+                "has_body_flag": 1,
+                "sent_flag": 1,
+                "sent_from_pipedrive_flag": 1,
+                "smart_bcc_flag": 0,
+                "message_time": "2024-11-15T10:30:00Z",
+                "add_time": "2024-11-15T10:30:05Z",
+                "update_time": "2024-11-15T11:00:00Z",
+                "has_attachments_flag": 0,
+                "has_inline_attachments_flag": 0,
+                "has_real_attachments_flag": 0,
+                "deal_id": 835,
+                "lead_id": null
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseMailMessage);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+
+        var message = response.Data;
+        Assert.Equal(12345, message.Id);
+        Assert.Equal("Follow-up on our discussion", message.Subject);
+        Assert.Equal("Hi John, I wanted to follow up on our conversation yesterday...", message.Snippet);
+        Assert.Contains("Hi John", message.Body);
+        Assert.Equal("abc123", message.AccountId);
+        Assert.Equal(555, message.UserId);
+        Assert.Equal(999, message.MailThreadId);
+        Assert.Equal("opened", message.MailTrackingStatus);
+        Assert.Equal(1, message.MailLinkTrackingEnabledFlag);
+        Assert.Equal(1, message.ReadFlag);
+        Assert.Equal(0, message.DraftFlag);
+        Assert.Equal(1, message.SyncedFlag);
+        Assert.Equal(0, message.DeletedFlag);
+        Assert.Equal(1, message.HasBodyFlag);
+        Assert.Equal(1, message.SentFlag);
+        Assert.Equal(1, message.SentFromPipedriveFlag);
+        Assert.Equal(0, message.SmartBccFlag);
+        Assert.Equal("2024-11-15T10:30:00Z", message.MessageTime);
+        Assert.Equal(0, message.HasAttachmentsFlag);
+        Assert.Equal(835, message.DealId);
+        Assert.Null(message.LeadId);
+
+        // Check from/to parties
+        Assert.NotNull(message.From);
+        Assert.Single(message.From);
+        Assert.Equal("sender@company.com", message.From[0].EmailAddress);
+        Assert.Equal("Sales Rep", message.From[0].Name);
+
+        Assert.NotNull(message.To);
+        Assert.Single(message.To);
+        Assert.Equal("prospect@customer.com", message.To[0].EmailAddress);
+
+        Assert.NotNull(message.Cc);
+        Assert.Single(message.Cc);
+        Assert.Equal("manager@company.com", message.Cc[0].EmailAddress);
+    }
+
+    /// <summary>
+    /// Test deserializing a list of mail messages (for deal/person endpoints)
+    /// </summary>
+    [Fact]
+    public void MailMessageList_Deserialization_WithPagination()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": true,
+            "data": [
+                {
+                    "id": 100,
+                    "from": [{"id": 1, "email_address": "sales@company.com", "name": "Sales"}],
+                    "to": [{"id": 2, "email_address": "customer@client.com", "name": "Customer"}],
+                    "subject": "First email",
+                    "snippet": "First message content...",
+                    "message_time": "2024-11-01T10:00:00Z",
+                    "read_flag": 1,
+                    "sent_flag": 1,
+                    "has_attachments_flag": 0
+                },
+                {
+                    "id": 101,
+                    "from": [{"id": 2, "email_address": "customer@client.com", "name": "Customer"}],
+                    "to": [{"id": 1, "email_address": "sales@company.com", "name": "Sales"}],
+                    "subject": "Re: First email",
+                    "snippet": "Reply content...",
+                    "message_time": "2024-11-02T14:00:00Z",
+                    "read_flag": 1,
+                    "sent_flag": 0,
+                    "has_attachments_flag": 1
+                }
+            ],
+            "additional_data": {
+                "pagination": {
+                    "start": 0,
+                    "limit": 50,
+                    "more_items_in_collection": true,
+                    "next_start": 50
+                }
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseListMailMessage);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Equal(2, response.Data.Count);
+
+        // First message (sent)
+        var msg1 = response.Data[0];
+        Assert.Equal(100, msg1.Id);
+        Assert.Equal("First email", msg1.Subject);
+        Assert.Equal(1, msg1.SentFlag);
+        Assert.Equal(0, msg1.HasAttachmentsFlag);
+
+        // Second message (received)
+        var msg2 = response.Data[1];
+        Assert.Equal(101, msg2.Id);
+        Assert.Equal("Re: First email", msg2.Subject);
+        Assert.Equal(0, msg2.SentFlag);
+        Assert.Equal(1, msg2.HasAttachmentsFlag);
+
+        // Pagination
+        Assert.NotNull(response.AdditionalData?.Pagination);
+        Assert.Equal(0, response.AdditionalData.Pagination.Start);
+        Assert.Equal(50, response.AdditionalData.Pagination.Limit);
+        Assert.True(response.AdditionalData.Pagination.MoreItemsInCollection);
+        Assert.Equal(50, response.AdditionalData.Pagination.NextStart);
+    }
+
+    /// <summary>
+    /// Test handling empty mail message list
+    /// </summary>
+    [Fact]
+    public void MailMessageList_Deserialization_EmptyList()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": true,
+            "data": [],
+            "additional_data": {
+                "pagination": {
+                    "start": 0,
+                    "limit": 50,
+                    "more_items_in_collection": false
+                }
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseListMailMessage);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Empty(response.Data);
+    }
+
+    /// <summary>
+    /// Test handling API error response
+    /// </summary>
+    [Fact]
+    public void MailMessage_Deserialization_ErrorResponse()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": false,
+            "error": "Mail message not found",
+            "error_info": "No mail message with ID 999999",
+            "data": null
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseMailMessage);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.False(response.Success);
+        Assert.Equal("Mail message not found", response.Error);
+        Assert.Equal("No mail message with ID 999999", response.ErrorInfo);
+        Assert.Null(response.Data);
+    }
+
+    #endregion
+
+    #region MailThread Tests
+
+    /// <summary>
+    /// Test that MailThread deserialization handles full API response
+    /// </summary>
+    [Fact]
+    public void MailThread_Deserialization_FullApiResponse()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "id": 55555,
+                "account_id": "account-xyz",
+                "user_id": 100,
+                "subject": "Product Demo Discussion",
+                "snippet": "Thanks for the demo, I have a few questions...",
+                "snippet_draft": null,
+                "snippet_sent": "Looking forward to our call next week.",
+                "read_flag": 1,
+                "mail_tracking_status": "clicked",
+                "has_attachments_flag": 1,
+                "has_inline_attachments_flag": 0,
+                "has_real_attachments_flag": 1,
+                "deleted_flag": 0,
+                "synced_flag": 1,
+                "smart_bcc_flag": 1,
+                "mail_link_tracking_enabled_flag": 1,
+                "parties": {
+                    "from": [
+                        {
+                            "id": 1,
+                            "email_address": "sales@company.com",
+                            "name": "Sales Team",
+                            "linked_person_id": 500
+                        }
+                    ],
+                    "to": [
+                        {
+                            "id": 2,
+                            "email_address": "buyer@enterprise.com",
+                            "name": "Enterprise Buyer",
+                            "linked_person_id": 600
+                        }
+                    ]
+                },
+                "folders": ["inbox", "important"],
+                "version": 12345678901,
+                "message_count": 8,
+                "has_draft_flag": 0,
+                "has_sent_flag": 1,
+                "archived_flag": 0,
+                "shared_flag": 1,
+                "external_deleted_flag": 0,
+                "first_message_to_me_flag": 0,
+                "all_messages_sent_flag": 0,
+                "last_message_timestamp": "2024-11-20T16:45:00Z",
+                "first_message_timestamp": "2024-11-10T09:00:00Z",
+                "last_message_sent_timestamp": "2024-11-19T14:30:00Z",
+                "last_message_received_timestamp": "2024-11-20T16:45:00Z",
+                "add_time": "2024-11-10T09:00:00Z",
+                "update_time": "2024-11-20T16:45:00Z",
+                "deal_id": 835,
+                "deal_status": "open",
+                "lead_id": null
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseMailThread);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+
+        var thread = response.Data;
+        Assert.Equal(55555, thread.Id);
+        Assert.Equal("account-xyz", thread.AccountId);
+        Assert.Equal(100, thread.UserId);
+        Assert.Equal("Product Demo Discussion", thread.Subject);
+        Assert.Equal("Thanks for the demo, I have a few questions...", thread.Snippet);
+        Assert.Null(thread.SnippetDraft);
+        Assert.Equal("Looking forward to our call next week.", thread.SnippetSent);
+        Assert.Equal(1, thread.ReadFlag);
+        Assert.Equal("clicked", thread.MailTrackingStatus);
+        Assert.Equal(1, thread.HasAttachmentsFlag);
+        Assert.Equal(1, thread.HasRealAttachmentsFlag);
+        Assert.Equal(0, thread.DeletedFlag);
+        Assert.Equal(1, thread.SyncedFlag);
+        Assert.Equal(1, thread.SmartBccFlag);
+        Assert.Equal(8, thread.MessageCount);
+        Assert.Equal(0, thread.HasDraftFlag);
+        Assert.Equal(1, thread.HasSentFlag);
+        Assert.Equal(0, thread.ArchivedFlag);
+        Assert.Equal(1, thread.SharedFlag);
+        Assert.Equal("2024-11-20T16:45:00Z", thread.LastMessageTimestamp);
+        Assert.Equal("2024-11-10T09:00:00Z", thread.FirstMessageTimestamp);
+        Assert.Equal(835, thread.DealId);
+        Assert.Equal("open", thread.DealStatus);
+        Assert.Null(thread.LeadId);
+
+        // Check parties
+        Assert.NotNull(thread.Parties);
+        Assert.NotNull(thread.Parties.From);
+        Assert.Single(thread.Parties.From);
+        Assert.Equal("sales@company.com", thread.Parties.From[0].EmailAddress);
+        Assert.NotNull(thread.Parties.To);
+        Assert.Single(thread.Parties.To);
+        Assert.Equal("buyer@enterprise.com", thread.Parties.To[0].EmailAddress);
+
+        // Check folders
+        Assert.NotNull(thread.Folders);
+        Assert.Equal(2, thread.Folders.Count);
+        Assert.Contains("inbox", thread.Folders);
+        Assert.Contains("important", thread.Folders);
+    }
+
+    /// <summary>
+    /// Test deserializing a list of mail threads
+    /// </summary>
+    [Fact]
+    public void MailThreadList_Deserialization_WithPagination()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": true,
+            "data": [
+                {
+                    "id": 1001,
+                    "subject": "Initial Inquiry",
+                    "snippet": "I'm interested in your product...",
+                    "message_count": 3,
+                    "read_flag": 1,
+                    "has_attachments_flag": 0,
+                    "folders": ["inbox"],
+                    "last_message_timestamp": "2024-11-15T10:00:00Z",
+                    "parties": {
+                        "from": [{"email_address": "lead@prospect.com", "name": "Lead"}],
+                        "to": [{"email_address": "sales@company.com", "name": "Sales"}]
+                    },
+                    "deal_id": 100
+                },
+                {
+                    "id": 1002,
+                    "subject": "Partnership Proposal",
+                    "snippet": "We'd like to discuss a partnership...",
+                    "message_count": 5,
+                    "read_flag": 0,
+                    "has_attachments_flag": 1,
+                    "folders": ["inbox", "starred"],
+                    "last_message_timestamp": "2024-11-18T14:30:00Z",
+                    "parties": {
+                        "from": [{"email_address": "partner@partner.com", "name": "Partner"}],
+                        "to": [{"email_address": "sales@company.com", "name": "Sales"}]
+                    },
+                    "deal_id": null
+                }
+            ],
+            "additional_data": {
+                "pagination": {
+                    "start": 0,
+                    "limit": 50,
+                    "more_items_in_collection": true,
+                    "next_start": 50
+                }
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseListMailThread);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Equal(2, response.Data.Count);
+
+        // First thread
+        var thread1 = response.Data[0];
+        Assert.Equal(1001, thread1.Id);
+        Assert.Equal("Initial Inquiry", thread1.Subject);
+        Assert.Equal(3, thread1.MessageCount);
+        Assert.Equal(1, thread1.ReadFlag);
+        Assert.Equal(0, thread1.HasAttachmentsFlag);
+        Assert.Equal(100, thread1.DealId);
+
+        // Second thread (unread, with attachments)
+        var thread2 = response.Data[1];
+        Assert.Equal(1002, thread2.Id);
+        Assert.Equal("Partnership Proposal", thread2.Subject);
+        Assert.Equal(5, thread2.MessageCount);
+        Assert.Equal(0, thread2.ReadFlag);
+        Assert.Equal(1, thread2.HasAttachmentsFlag);
+        Assert.Null(thread2.DealId);
+        Assert.NotNull(thread2.Folders);
+        Assert.Contains("starred", thread2.Folders);
+
+        // Pagination
+        Assert.NotNull(response.AdditionalData?.Pagination);
+        Assert.True(response.AdditionalData.Pagination.MoreItemsInCollection);
+    }
+
+    /// <summary>
+    /// Test handling empty thread list
+    /// </summary>
+    [Fact]
+    public void MailThreadList_Deserialization_EmptyList()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": true,
+            "data": [],
+            "additional_data": {
+                "pagination": {
+                    "start": 0,
+                    "limit": 50,
+                    "more_items_in_collection": false
+                }
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseListMailThread);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Empty(response.Data);
+    }
+
+    /// <summary>
+    /// Test thread with archived flag
+    /// </summary>
+    [Fact]
+    public void MailThread_Deserialization_ArchivedThread()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "id": 9999,
+                "subject": "Old Conversation",
+                "snippet": "This conversation is archived",
+                "message_count": 10,
+                "read_flag": 1,
+                "archived_flag": 1,
+                "folders": ["archive"],
+                "last_message_timestamp": "2024-01-01T10:00:00Z",
+                "deal_id": null
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseMailThread);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Equal(9999, response.Data.Id);
+        Assert.Equal(1, response.Data.ArchivedFlag);
+        Assert.NotNull(response.Data.Folders);
+        Assert.Contains("archive", response.Data.Folders);
+    }
+
+    /// <summary>
+    /// Test thread associated with a lead
+    /// </summary>
+    [Fact]
+    public void MailThread_Deserialization_WithLeadAssociation()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "id": 7777,
+                "subject": "New Lead Inquiry",
+                "snippet": "I found your website and I'm interested...",
+                "message_count": 2,
+                "read_flag": 0,
+                "folders": ["inbox"],
+                "last_message_timestamp": "2024-11-20T09:00:00Z",
+                "deal_id": null,
+                "lead_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseMailThread);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Equal(7777, response.Data.Id);
+        Assert.Null(response.Data.DealId);
+        Assert.Equal("a1b2c3d4-e5f6-7890-abcd-ef1234567890", response.Data.LeadId);
+    }
+
+    /// <summary>
+    /// Test thread with draft
+    /// </summary>
+    [Fact]
+    public void MailThread_Deserialization_WithDraft()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "id": 6666,
+                "subject": "Proposal Draft",
+                "snippet": "Latest message...",
+                "snippet_draft": "I'm working on a proposal that includes...",
+                "message_count": 4,
+                "has_draft_flag": 1,
+                "read_flag": 1,
+                "folders": ["drafts", "inbox"],
+                "last_message_timestamp": "2024-11-19T15:00:00Z"
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseMailThread);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Equal(6666, response.Data.Id);
+        Assert.Equal(1, response.Data.HasDraftFlag);
+        Assert.Equal("I'm working on a proposal that includes...", response.Data.SnippetDraft);
+        Assert.NotNull(response.Data.Folders);
+        Assert.Contains("drafts", response.Data.Folders);
+    }
+
+    #endregion
+
+    #region MailThreadParties Tests
+
+    /// <summary>
+    /// Test MailThreadParties deserialization with multiple parties
+    /// </summary>
+    [Fact]
+    public void MailThreadParties_Deserialization_MultipleParties()
+    {
+        // Arrange
+        var json = """
+        {
+            "from": [
+                {"email_address": "sender1@company.com", "name": "Sender 1"},
+                {"email_address": "sender2@company.com", "name": "Sender 2"}
+            ],
+            "to": [
+                {"email_address": "recipient1@client.com", "name": "Recipient 1"},
+                {"email_address": "recipient2@client.com", "name": "Recipient 2"},
+                {"email_address": "recipient3@client.com", "name": "Recipient 3"}
+            ]
+        }
+        """;
+
+        // Act
+        var parties = JsonSerializer.Deserialize(json, ApiJsonContext.Default.MailThreadParties);
+
+        // Assert
+        Assert.NotNull(parties);
+        Assert.NotNull(parties.From);
+        Assert.Equal(2, parties.From.Count);
+        Assert.NotNull(parties.To);
+        Assert.Equal(3, parties.To.Count);
+    }
+
+    /// <summary>
+    /// Test MailThreadParties with empty lists
+    /// </summary>
+    [Fact]
+    public void MailThreadParties_Deserialization_EmptyParties()
+    {
+        // Arrange
+        var json = """
+        {
+            "from": [],
+            "to": []
+        }
+        """;
+
+        // Act
+        var parties = JsonSerializer.Deserialize(json, ApiJsonContext.Default.MailThreadParties);
+
+        // Assert
+        Assert.NotNull(parties);
+        Assert.NotNull(parties.From);
+        Assert.Empty(parties.From);
+        Assert.NotNull(parties.To);
+        Assert.Empty(parties.To);
+    }
+
+    #endregion
+
+    #region Edge Cases
+
+    /// <summary>
+    /// Test mail message with no body (body_url only)
+    /// </summary>
+    [Fact]
+    public void MailMessage_Deserialization_NoBodyContent()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "id": 88888,
+                "subject": "Quick question",
+                "snippet": "Do you have time for a call?",
+                "body": null,
+                "body_url": "https://api.pipedrive.com/v1/mailbox/mailMessages/88888/body",
+                "has_body_flag": 1,
+                "from": [{"email_address": "sender@test.com"}],
+                "to": [{"email_address": "recipient@test.com"}]
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseMailMessage);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Data);
+        Assert.Null(response.Data.Body);
+        Assert.NotNull(response.Data.BodyUrl);
+        Assert.Equal(1, response.Data.HasBodyFlag);
+    }
+
+    /// <summary>
+    /// Test mail message that was sent via Smart BCC
+    /// </summary>
+    [Fact]
+    public void MailMessage_Deserialization_SmartBcc()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "id": 77777,
+                "subject": "External Email via BCC",
+                "snippet": "This email was tracked via Smart BCC",
+                "smart_bcc_flag": 1,
+                "sent_from_pipedrive_flag": 0,
+                "sent_flag": 1,
+                "from": [{"email_address": "sales@company.com"}],
+                "to": [{"email_address": "customer@external.com"}]
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseMailMessage);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Data);
+        Assert.Equal(1, response.Data.SmartBccFlag);
+        Assert.Equal(0, response.Data.SentFromPipedriveFlag);
+        Assert.Equal(1, response.Data.SentFlag);
+    }
+
+    /// <summary>
+    /// Test thread error response
+    /// </summary>
+    [Fact]
+    public void MailThread_Deserialization_ErrorResponse()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": false,
+            "error": "Thread not found",
+            "error_info": "No mail thread with ID 999999",
+            "data": null
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseMailThread);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.False(response.Success);
+        Assert.Equal("Thread not found", response.Error);
+        Assert.Null(response.Data);
+    }
+
+    #endregion
+}

--- a/src/PipedriveCLI/Commands/EmailsCommands.cs
+++ b/src/PipedriveCLI/Commands/EmailsCommands.cs
@@ -1,0 +1,691 @@
+using System.CommandLine;
+using System.Text.RegularExpressions;
+using PipedriveCLI.Models;
+using PipedriveCLI.Services;
+using Spectre.Console;
+
+namespace PipedriveCLI.Commands;
+
+/// <summary>
+/// Commands for viewing email history in Pipedrive
+/// </summary>
+public static class EmailsCommands
+{
+    /// <summary>
+    /// Creates the root 'emails' command with all subcommands
+    /// </summary>
+    public static Command CreateEmailsCommand(PipedriveApiClient apiClient)
+    {
+        var emailsCommand = new Command("emails", "View email history and conversations");
+
+        // Add subcommands
+        emailsCommand.AddCommand(CreateListForDealCommand(apiClient));
+        emailsCommand.AddCommand(CreateListForPersonCommand(apiClient));
+        emailsCommand.AddCommand(CreateGetCommand(apiClient));
+        emailsCommand.AddCommand(CreateThreadsCommand(apiClient));
+        emailsCommand.AddCommand(CreateThreadCommand(apiClient));
+        emailsCommand.AddCommand(CreateThreadMessagesCommand(apiClient));
+
+        return emailsCommand;
+    }
+
+    /// <summary>
+    /// Creates the 'emails list-for-deal' command
+    /// </summary>
+    private static Command CreateListForDealCommand(PipedriveApiClient apiClient)
+    {
+        var listCommand = new Command("list-for-deal", "List emails associated with a deal");
+
+        var dealIdArgument = new Argument<int>("deal-id", "Deal ID");
+        listCommand.AddArgument(dealIdArgument);
+
+        var limitOption = new Option<int?>(
+            aliases: ["--limit", "-l"],
+            description: "Number of emails to return (default: 50)");
+
+        var startOption = new Option<int?>(
+            aliases: ["--start", "-s"],
+            description: "Pagination start (default: 0)");
+
+        listCommand.AddOption(limitOption);
+        listCommand.AddOption(startOption);
+
+        listCommand.SetHandler(async (dealId, limit, start) =>
+        {
+            try
+            {
+                await apiClient.InitializeAsync();
+
+                await AnsiConsole.Status()
+                    .StartAsync($"Fetching emails for deal {dealId}...", async ctx =>
+                    {
+                        ctx.Spinner(Spinner.Known.Dots);
+                        ctx.SpinnerStyle(Style.Parse("green"));
+
+                        var response = await apiClient.GetMailMessagesForDealAsync(dealId, limit ?? 50, start);
+
+                        if (response?.Success == true && response.Data != null)
+                        {
+                            ctx.Status("Formatting results...");
+                            DisplayMailMessageList(response.Data, response.AdditionalData?.Pagination);
+                        }
+                        else
+                        {
+                            AnsiConsole.MarkupLine($"[red]✗[/] Failed to fetch emails: {Markup.Escape(response?.Error ?? "Unknown error")}");
+                        }
+                    });
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
+            }
+        }, dealIdArgument, limitOption, startOption);
+
+        return listCommand;
+    }
+
+    /// <summary>
+    /// Creates the 'emails list-for-person' command
+    /// </summary>
+    private static Command CreateListForPersonCommand(PipedriveApiClient apiClient)
+    {
+        var listCommand = new Command("list-for-person", "List emails associated with a person");
+
+        var personIdArgument = new Argument<int>("person-id", "Person ID");
+        listCommand.AddArgument(personIdArgument);
+
+        var limitOption = new Option<int?>(
+            aliases: ["--limit", "-l"],
+            description: "Number of emails to return (default: 50)");
+
+        var startOption = new Option<int?>(
+            aliases: ["--start", "-s"],
+            description: "Pagination start (default: 0)");
+
+        listCommand.AddOption(limitOption);
+        listCommand.AddOption(startOption);
+
+        listCommand.SetHandler(async (personId, limit, start) =>
+        {
+            try
+            {
+                await apiClient.InitializeAsync();
+
+                await AnsiConsole.Status()
+                    .StartAsync($"Fetching emails for person {personId}...", async ctx =>
+                    {
+                        ctx.Spinner(Spinner.Known.Dots);
+                        ctx.SpinnerStyle(Style.Parse("green"));
+
+                        var response = await apiClient.GetMailMessagesForPersonAsync(personId, limit ?? 50, start);
+
+                        if (response?.Success == true && response.Data != null)
+                        {
+                            ctx.Status("Formatting results...");
+                            DisplayMailMessageList(response.Data, response.AdditionalData?.Pagination);
+                        }
+                        else
+                        {
+                            AnsiConsole.MarkupLine($"[red]✗[/] Failed to fetch emails: {Markup.Escape(response?.Error ?? "Unknown error")}");
+                        }
+                    });
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
+            }
+        }, personIdArgument, limitOption, startOption);
+
+        return listCommand;
+    }
+
+    /// <summary>
+    /// Creates the 'emails get' command
+    /// </summary>
+    private static Command CreateGetCommand(PipedriveApiClient apiClient)
+    {
+        var getCommand = new Command("get", "Get a specific email message by ID");
+
+        var idArgument = new Argument<int>("message-id", "Email message ID");
+        getCommand.AddArgument(idArgument);
+
+        var includeBodyOption = new Option<bool>(
+            aliases: ["--include-body", "-b"],
+            description: "Include the full email body content");
+
+        getCommand.AddOption(includeBodyOption);
+
+        getCommand.SetHandler(async (id, includeBody) =>
+        {
+            try
+            {
+                await apiClient.InitializeAsync();
+
+                var response = await AnsiConsole.Status()
+                    .StartAsync($"Fetching email {id}...", async ctx =>
+                    {
+                        ctx.Spinner(Spinner.Known.Dots);
+                        ctx.SpinnerStyle(Style.Parse("green"));
+                        return await apiClient.GetMailMessageByIdAsync(id, includeBody);
+                    });
+
+                if (response?.Success == true && response.Data != null)
+                {
+                    DisplayMailMessageDetail(response.Data, includeBody);
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine($"[red]✗[/] Failed to fetch email: {Markup.Escape(response?.Error ?? "Unknown error")}");
+                }
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
+            }
+        }, idArgument, includeBodyOption);
+
+        return getCommand;
+    }
+
+    /// <summary>
+    /// Creates the 'emails threads' command
+    /// </summary>
+    private static Command CreateThreadsCommand(PipedriveApiClient apiClient)
+    {
+        var threadsCommand = new Command("threads", "List mail threads by folder");
+
+        var folderOption = new Option<string?>(
+            aliases: ["--folder", "-f"],
+            description: "Filter by folder: inbox, sent, drafts, archive");
+
+        var limitOption = new Option<int?>(
+            aliases: ["--limit", "-l"],
+            description: "Number of threads to return (default: 50)");
+
+        var startOption = new Option<int?>(
+            aliases: ["--start", "-s"],
+            description: "Pagination start (default: 0)");
+
+        threadsCommand.AddOption(folderOption);
+        threadsCommand.AddOption(limitOption);
+        threadsCommand.AddOption(startOption);
+
+        threadsCommand.SetHandler(async (folder, limit, start) =>
+        {
+            try
+            {
+                await apiClient.InitializeAsync();
+
+                var statusText = string.IsNullOrWhiteSpace(folder)
+                    ? "Fetching mail threads..."
+                    : $"Fetching {folder} mail threads...";
+
+                await AnsiConsole.Status()
+                    .StartAsync(statusText, async ctx =>
+                    {
+                        ctx.Spinner(Spinner.Known.Dots);
+                        ctx.SpinnerStyle(Style.Parse("green"));
+
+                        var response = await apiClient.GetMailThreadsAsync(folder, limit ?? 50, start);
+
+                        if (response?.Success == true && response.Data != null)
+                        {
+                            ctx.Status("Formatting results...");
+                            DisplayMailThreadList(response.Data, response.AdditionalData?.Pagination);
+                        }
+                        else
+                        {
+                            AnsiConsole.MarkupLine($"[red]✗[/] Failed to fetch mail threads: {Markup.Escape(response?.Error ?? "Unknown error")}");
+                        }
+                    });
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
+            }
+        }, folderOption, limitOption, startOption);
+
+        return threadsCommand;
+    }
+
+    /// <summary>
+    /// Creates the 'emails thread' command
+    /// </summary>
+    private static Command CreateThreadCommand(PipedriveApiClient apiClient)
+    {
+        var threadCommand = new Command("thread", "Get a specific mail thread by ID");
+
+        var idArgument = new Argument<int>("thread-id", "Thread ID");
+        threadCommand.AddArgument(idArgument);
+
+        threadCommand.SetHandler(async (id) =>
+        {
+            try
+            {
+                await apiClient.InitializeAsync();
+
+                var response = await AnsiConsole.Status()
+                    .StartAsync($"Fetching thread {id}...", async ctx =>
+                    {
+                        ctx.Spinner(Spinner.Known.Dots);
+                        ctx.SpinnerStyle(Style.Parse("green"));
+                        return await apiClient.GetMailThreadByIdAsync(id);
+                    });
+
+                if (response?.Success == true && response.Data != null)
+                {
+                    DisplayMailThreadDetail(response.Data);
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine($"[red]✗[/] Failed to fetch thread: {Markup.Escape(response?.Error ?? "Unknown error")}");
+                }
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
+            }
+        }, idArgument);
+
+        return threadCommand;
+    }
+
+    /// <summary>
+    /// Creates the 'emails thread-messages' command
+    /// </summary>
+    private static Command CreateThreadMessagesCommand(PipedriveApiClient apiClient)
+    {
+        var threadMessagesCommand = new Command("thread-messages", "Get all messages in a thread");
+
+        var idArgument = new Argument<int>("thread-id", "Thread ID");
+        threadMessagesCommand.AddArgument(idArgument);
+
+        var includeBodyOption = new Option<bool>(
+            aliases: ["--include-body", "-b"],
+            description: "Include the full email body content for each message");
+
+        threadMessagesCommand.AddOption(includeBodyOption);
+
+        threadMessagesCommand.SetHandler(async (id, includeBody) =>
+        {
+            try
+            {
+                await apiClient.InitializeAsync();
+
+                var response = await AnsiConsole.Status()
+                    .StartAsync($"Fetching messages in thread {id}...", async ctx =>
+                    {
+                        ctx.Spinner(Spinner.Known.Dots);
+                        ctx.SpinnerStyle(Style.Parse("green"));
+                        return await apiClient.GetMailThreadMessagesAsync(id);
+                    });
+
+                if (response?.Success == true && response.Data != null)
+                {
+                    if (includeBody)
+                    {
+                        // Display each message with full body
+                        foreach (var message in response.Data)
+                        {
+                            DisplayMailMessageDetail(message, includeBody);
+                            AnsiConsole.WriteLine();
+                        }
+                        AnsiConsole.MarkupLine($"\n[green]✓[/] Found {response.Data.Count} message(s) in thread");
+                    }
+                    else
+                    {
+                        DisplayMailMessageList(response.Data, null);
+                    }
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine($"[red]✗[/] Failed to fetch thread messages: {Markup.Escape(response?.Error ?? "Unknown error")}");
+                }
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
+            }
+        }, idArgument, includeBodyOption);
+
+        return threadMessagesCommand;
+    }
+
+    #region Display Helpers
+
+    /// <summary>
+    /// Displays a list of mail messages in a table format
+    /// </summary>
+    private static void DisplayMailMessageList(List<MailMessage> messages, Pagination? pagination)
+    {
+        var table = new Table();
+        table.Border(TableBorder.Rounded);
+        table.AddColumn("ID");
+        table.AddColumn("From");
+        table.AddColumn("To");
+        table.AddColumn("Subject");
+        table.AddColumn("Date");
+        table.AddColumn("Snippet");
+
+        foreach (var message in messages)
+        {
+            var from = FormatParty(message.From?.FirstOrDefault());
+            var to = FormatParty(message.To?.FirstOrDefault());
+            var subject = TruncateAndEscape(message.Subject, 40);
+            var snippet = TruncateAndEscape(message.Snippet, 50);
+            var date = FormatDateTime(message.MessageTime);
+
+            table.AddRow(
+                message.Id.ToString(),
+                from,
+                to,
+                subject,
+                date,
+                snippet
+            );
+        }
+
+        AnsiConsole.Write(table);
+
+        if (pagination != null)
+        {
+            AnsiConsole.MarkupLine($"\n[dim]Showing {pagination.Start + 1}-{pagination.Start + messages.Count} " +
+                $"| More available: {pagination.MoreItemsInCollection}[/]");
+        }
+
+        AnsiConsole.MarkupLine($"\n[green]✓[/] Found {messages.Count} email(s)");
+    }
+
+    /// <summary>
+    /// Displays detailed information about a single mail message
+    /// </summary>
+    private static void DisplayMailMessageDetail(MailMessage message, bool includeBody)
+    {
+        var from = FormatParties(message.From);
+        var to = FormatParties(message.To);
+        var cc = FormatParties(message.Cc);
+        var bcc = FormatParties(message.Bcc);
+
+        var content = new System.Text.StringBuilder();
+        content.AppendLine($"[bold]ID:[/] {message.Id}");
+        content.AppendLine($"[bold]Thread ID:[/] {message.MailThreadId?.ToString() ?? "N/A"}");
+        content.AppendLine($"[bold]Subject:[/] {Markup.Escape(message.Subject ?? "")}");
+        content.AppendLine($"[bold]From:[/] {from}");
+        content.AppendLine($"[bold]To:[/] {to}");
+
+        if (!string.IsNullOrWhiteSpace(cc))
+        {
+            content.AppendLine($"[bold]CC:[/] {cc}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(bcc))
+        {
+            content.AppendLine($"[bold]BCC:[/] {bcc}");
+        }
+
+        content.AppendLine($"[bold]Date:[/] {FormatDateTime(message.MessageTime)}");
+        content.AppendLine($"[bold]Read:[/] {(message.ReadFlag == 1 ? "Yes" : "No")}");
+        content.AppendLine($"[bold]Sent:[/] {(message.SentFlag == 1 ? "Yes" : "No")}");
+        content.AppendLine($"[bold]Has Attachments:[/] {(message.HasAttachmentsFlag == 1 ? "Yes" : "No")}");
+
+        if (message.DealId.HasValue)
+        {
+            content.AppendLine($"[bold]Deal ID:[/] {message.DealId}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(message.LeadId))
+        {
+            content.AppendLine($"[bold]Lead ID:[/] {message.LeadId}");
+        }
+
+        if (includeBody && !string.IsNullOrWhiteSpace(message.Body))
+        {
+            content.AppendLine();
+            content.AppendLine("[bold]Body:[/]");
+            // Strip HTML tags for terminal display
+            var plainBody = StripHtml(message.Body);
+            content.AppendLine(Markup.Escape(plainBody));
+        }
+        else if (!string.IsNullOrWhiteSpace(message.Snippet))
+        {
+            content.AppendLine();
+            content.AppendLine($"[bold]Snippet:[/] {Markup.Escape(message.Snippet)}");
+        }
+
+        var panel = new Panel(new Markup(content.ToString()))
+        {
+            Header = new PanelHeader($"[green]Email {message.Id}[/]"),
+            Border = BoxBorder.Rounded
+        };
+
+        AnsiConsole.Write(panel);
+    }
+
+    /// <summary>
+    /// Displays a list of mail threads in a table format
+    /// </summary>
+    private static void DisplayMailThreadList(List<MailThread> threads, Pagination? pagination)
+    {
+        var table = new Table();
+        table.Border(TableBorder.Rounded);
+        table.AddColumn("ID");
+        table.AddColumn("From");
+        table.AddColumn("To");
+        table.AddColumn("Subject");
+        table.AddColumn("Messages");
+        table.AddColumn("Last Message");
+        table.AddColumn("Folders");
+
+        foreach (var thread in threads)
+        {
+            var from = FormatParty(thread.Parties?.From?.FirstOrDefault());
+            var to = FormatParty(thread.Parties?.To?.FirstOrDefault());
+            var subject = TruncateAndEscape(thread.Subject, 40);
+            var lastMessage = FormatDateTime(thread.LastMessageTimestamp);
+            var folders = thread.Folders != null ? string.Join(", ", thread.Folders) : "-";
+
+            table.AddRow(
+                thread.Id.ToString(),
+                from,
+                to,
+                subject,
+                thread.MessageCount?.ToString() ?? "-",
+                lastMessage,
+                Markup.Escape(folders)
+            );
+        }
+
+        AnsiConsole.Write(table);
+
+        if (pagination != null)
+        {
+            AnsiConsole.MarkupLine($"\n[dim]Showing {pagination.Start + 1}-{pagination.Start + threads.Count} " +
+                $"| More available: {pagination.MoreItemsInCollection}[/]");
+        }
+
+        AnsiConsole.MarkupLine($"\n[green]✓[/] Found {threads.Count} thread(s)");
+    }
+
+    /// <summary>
+    /// Displays detailed information about a single mail thread
+    /// </summary>
+    private static void DisplayMailThreadDetail(MailThread thread)
+    {
+        var from = FormatParties(thread.Parties?.From);
+        var to = FormatParties(thread.Parties?.To);
+
+        var content = new System.Text.StringBuilder();
+        content.AppendLine($"[bold]ID:[/] {thread.Id}");
+        content.AppendLine($"[bold]Subject:[/] {Markup.Escape(thread.Subject ?? "")}");
+        content.AppendLine($"[bold]From:[/] {from}");
+        content.AppendLine($"[bold]To:[/] {to}");
+        content.AppendLine($"[bold]Message Count:[/] {thread.MessageCount?.ToString() ?? "0"}");
+        content.AppendLine($"[bold]Folders:[/] {(thread.Folders != null ? Markup.Escape(string.Join(", ", thread.Folders)) : "N/A")}");
+        content.AppendLine($"[bold]Read:[/] {(thread.ReadFlag == 1 ? "Yes" : "No")}");
+        content.AppendLine($"[bold]Archived:[/] {(thread.ArchivedFlag == 1 ? "Yes" : "No")}");
+        content.AppendLine($"[bold]Has Attachments:[/] {(thread.HasAttachmentsFlag == 1 ? "Yes" : "No")}");
+        content.AppendLine($"[bold]Has Draft:[/] {(thread.HasDraftFlag == 1 ? "Yes" : "No")}");
+        content.AppendLine($"[bold]First Message:[/] {FormatDateTime(thread.FirstMessageTimestamp)}");
+        content.AppendLine($"[bold]Last Message:[/] {FormatDateTime(thread.LastMessageTimestamp)}");
+
+        if (thread.DealId.HasValue)
+        {
+            content.AppendLine($"[bold]Deal ID:[/] {thread.DealId}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(thread.LeadId))
+        {
+            content.AppendLine($"[bold]Lead ID:[/] {thread.LeadId}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(thread.Snippet))
+        {
+            content.AppendLine();
+            content.AppendLine($"[bold]Latest Snippet:[/] {Markup.Escape(thread.Snippet)}");
+        }
+
+        var panel = new Panel(new Markup(content.ToString()))
+        {
+            Header = new PanelHeader($"[green]Thread {thread.Id}: {Markup.Escape(TruncateString(thread.Subject, 40))}[/]"),
+            Border = BoxBorder.Rounded
+        };
+
+        AnsiConsole.Write(panel);
+
+        AnsiConsole.MarkupLine($"\n[dim]Use 'pipedrive emails thread-messages {thread.Id}' to view all messages in this thread[/]");
+    }
+
+    /// <summary>
+    /// Formats a single mail party for display
+    /// </summary>
+    private static string FormatParty(MailParty? party)
+    {
+        if (party == null) return "-";
+
+        var name = party.Name ?? party.LinkedPersonName;
+        var email = party.EmailAddress;
+
+        if (!string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(email))
+        {
+            return Markup.Escape($"{name} <{email}>");
+        }
+        else if (!string.IsNullOrWhiteSpace(email))
+        {
+            return Markup.Escape(email);
+        }
+        else if (!string.IsNullOrWhiteSpace(name))
+        {
+            return Markup.Escape(name);
+        }
+
+        return "-";
+    }
+
+    /// <summary>
+    /// Formats a list of mail parties for display
+    /// </summary>
+    private static string FormatParties(List<MailParty>? parties)
+    {
+        if (parties == null || parties.Count == 0) return "-";
+
+        var formatted = parties.Select(p =>
+        {
+            var name = p.Name ?? p.LinkedPersonName;
+            var email = p.EmailAddress;
+
+            if (!string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(email))
+            {
+                return $"{name} <{email}>";
+            }
+            else if (!string.IsNullOrWhiteSpace(email))
+            {
+                return email;
+            }
+            else if (!string.IsNullOrWhiteSpace(name))
+            {
+                return name;
+            }
+            return null;
+        }).Where(s => s != null);
+
+        return Markup.Escape(string.Join("; ", formatted));
+    }
+
+    /// <summary>
+    /// Truncates a string and escapes it for Spectre.Console markup
+    /// </summary>
+    private static string TruncateAndEscape(string? text, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return "-";
+
+        var sanitized = text.Replace("\n", " ").Replace("\r", "");
+        if (sanitized.Length > maxLength)
+        {
+            sanitized = sanitized.Substring(0, maxLength) + "...";
+        }
+
+        return Markup.Escape(sanitized);
+    }
+
+    /// <summary>
+    /// Truncates a string without escaping
+    /// </summary>
+    private static string TruncateString(string? text, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return "";
+
+        if (text.Length > maxLength)
+        {
+            return text.Substring(0, maxLength) + "...";
+        }
+
+        return text;
+    }
+
+    /// <summary>
+    /// Formats a datetime string for display
+    /// </summary>
+    private static string FormatDateTime(string? dateTime)
+    {
+        if (string.IsNullOrWhiteSpace(dateTime)) return "-";
+
+        if (DateTime.TryParse(dateTime, out var dt))
+        {
+            return dt.ToString("yyyy-MM-dd HH:mm");
+        }
+
+        return Markup.Escape(dateTime);
+    }
+
+    /// <summary>
+    /// Strips HTML tags from a string for terminal display
+    /// </summary>
+    private static string StripHtml(string html)
+    {
+        if (string.IsNullOrWhiteSpace(html)) return "";
+
+        // Remove script and style elements completely
+        html = Regex.Replace(html, @"<script[^>]*>[\s\S]*?</script>", "", RegexOptions.IgnoreCase);
+        html = Regex.Replace(html, @"<style[^>]*>[\s\S]*?</style>", "", RegexOptions.IgnoreCase);
+
+        // Replace common block elements with newlines
+        html = Regex.Replace(html, @"<br\s*/?>", "\n", RegexOptions.IgnoreCase);
+        html = Regex.Replace(html, @"</p>", "\n\n", RegexOptions.IgnoreCase);
+        html = Regex.Replace(html, @"</div>", "\n", RegexOptions.IgnoreCase);
+        html = Regex.Replace(html, @"</li>", "\n", RegexOptions.IgnoreCase);
+
+        // Remove remaining HTML tags
+        html = Regex.Replace(html, @"<[^>]+>", "");
+
+        // Decode HTML entities
+        html = System.Net.WebUtility.HtmlDecode(html);
+
+        // Normalize whitespace
+        html = Regex.Replace(html, @"[ \t]+", " ");
+        html = Regex.Replace(html, @"\n{3,}", "\n\n");
+
+        return html.Trim();
+    }
+
+    #endregion
+}

--- a/src/PipedriveCLI/Models/ApiModels.cs
+++ b/src/PipedriveCLI/Models/ApiModels.cs
@@ -638,6 +638,261 @@ public sealed class Note
 }
 
 /// <summary>
+/// Email message party (sender/recipient) information
+/// </summary>
+public sealed class MailParty
+{
+    [JsonPropertyName("id")]
+    public int? Id { get; set; }
+
+    [JsonPropertyName("email_address")]
+    public string? EmailAddress { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("linked_person_id")]
+    public int? LinkedPersonId { get; set; }
+
+    [JsonPropertyName("linked_person_name")]
+    public string? LinkedPersonName { get; set; }
+
+    [JsonPropertyName("linked_organization_id")]
+    public int? LinkedOrganizationId { get; set; }
+
+    [JsonPropertyName("mail_message_party_id")]
+    public int? MailMessagePartyId { get; set; }
+
+    [JsonPropertyName("latest_sent")]
+    public bool? LatestSent { get; set; }
+
+    [JsonPropertyName("message_time")]
+    public object? MessageTime { get; set; }
+}
+
+/// <summary>
+/// Pipedrive Mail Message model for email conversations
+/// </summary>
+public sealed class MailMessage
+{
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    [JsonPropertyName("from")]
+    public List<MailParty>? From { get; set; }
+
+    [JsonPropertyName("to")]
+    public List<MailParty>? To { get; set; }
+
+    [JsonPropertyName("cc")]
+    public List<MailParty>? Cc { get; set; }
+
+    [JsonPropertyName("bcc")]
+    public List<MailParty>? Bcc { get; set; }
+
+    [JsonPropertyName("subject")]
+    public string? Subject { get; set; }
+
+    [JsonPropertyName("snippet")]
+    public string? Snippet { get; set; }
+
+    [JsonPropertyName("body")]
+    public string? Body { get; set; }
+
+    [JsonPropertyName("body_url")]
+    public string? BodyUrl { get; set; }
+
+    [JsonPropertyName("account_id")]
+    public string? AccountId { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public int? UserId { get; set; }
+
+    [JsonPropertyName("mail_thread_id")]
+    public int? MailThreadId { get; set; }
+
+    [JsonPropertyName("mail_tracking_status")]
+    public string? MailTrackingStatus { get; set; }
+
+    [JsonPropertyName("mail_link_tracking_enabled_flag")]
+    public int? MailLinkTrackingEnabledFlag { get; set; }
+
+    [JsonPropertyName("read_flag")]
+    public int? ReadFlag { get; set; }
+
+    [JsonPropertyName("draft_flag")]
+    public int? DraftFlag { get; set; }
+
+    [JsonPropertyName("synced_flag")]
+    public int? SyncedFlag { get; set; }
+
+    [JsonPropertyName("deleted_flag")]
+    public int? DeletedFlag { get; set; }
+
+    [JsonPropertyName("has_body_flag")]
+    public int? HasBodyFlag { get; set; }
+
+    [JsonPropertyName("sent_flag")]
+    public int? SentFlag { get; set; }
+
+    [JsonPropertyName("sent_from_pipedrive_flag")]
+    public int? SentFromPipedriveFlag { get; set; }
+
+    [JsonPropertyName("smart_bcc_flag")]
+    public int? SmartBccFlag { get; set; }
+
+    [JsonPropertyName("message_time")]
+    public string? MessageTime { get; set; }
+
+    [JsonPropertyName("add_time")]
+    public string? AddTime { get; set; }
+
+    [JsonPropertyName("update_time")]
+    public string? UpdateTime { get; set; }
+
+    [JsonPropertyName("has_attachments_flag")]
+    public int? HasAttachmentsFlag { get; set; }
+
+    [JsonPropertyName("has_inline_attachments_flag")]
+    public int? HasInlineAttachmentsFlag { get; set; }
+
+    [JsonPropertyName("has_real_attachments_flag")]
+    public int? HasRealAttachmentsFlag { get; set; }
+
+    [JsonPropertyName("deal_id")]
+    public int? DealId { get; set; }
+
+    [JsonPropertyName("lead_id")]
+    public string? LeadId { get; set; }
+}
+
+/// <summary>
+/// Parties information for a mail thread
+/// </summary>
+public sealed class MailThreadParties
+{
+    [JsonPropertyName("to")]
+    public List<MailParty>? To { get; set; }
+
+    [JsonPropertyName("from")]
+    public List<MailParty>? From { get; set; }
+}
+
+/// <summary>
+/// Pipedrive Mail Thread model for email thread management
+/// </summary>
+public sealed class MailThread
+{
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    [JsonPropertyName("account_id")]
+    public string? AccountId { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public int? UserId { get; set; }
+
+    [JsonPropertyName("subject")]
+    public string? Subject { get; set; }
+
+    [JsonPropertyName("snippet")]
+    public string? Snippet { get; set; }
+
+    [JsonPropertyName("snippet_draft")]
+    public string? SnippetDraft { get; set; }
+
+    [JsonPropertyName("snippet_sent")]
+    public string? SnippetSent { get; set; }
+
+    [JsonPropertyName("read_flag")]
+    public int? ReadFlag { get; set; }
+
+    [JsonPropertyName("mail_tracking_status")]
+    public string? MailTrackingStatus { get; set; }
+
+    [JsonPropertyName("has_attachments_flag")]
+    public int? HasAttachmentsFlag { get; set; }
+
+    [JsonPropertyName("has_inline_attachments_flag")]
+    public int? HasInlineAttachmentsFlag { get; set; }
+
+    [JsonPropertyName("has_real_attachments_flag")]
+    public int? HasRealAttachmentsFlag { get; set; }
+
+    [JsonPropertyName("deleted_flag")]
+    public int? DeletedFlag { get; set; }
+
+    [JsonPropertyName("synced_flag")]
+    public int? SyncedFlag { get; set; }
+
+    [JsonPropertyName("smart_bcc_flag")]
+    public int? SmartBccFlag { get; set; }
+
+    [JsonPropertyName("mail_link_tracking_enabled_flag")]
+    public int? MailLinkTrackingEnabledFlag { get; set; }
+
+    [JsonPropertyName("parties")]
+    public MailThreadParties? Parties { get; set; }
+
+    [JsonPropertyName("folders")]
+    public List<string>? Folders { get; set; }
+
+    [JsonPropertyName("version")]
+    public long? Version { get; set; }
+
+    [JsonPropertyName("message_count")]
+    public int? MessageCount { get; set; }
+
+    [JsonPropertyName("has_draft_flag")]
+    public int? HasDraftFlag { get; set; }
+
+    [JsonPropertyName("has_sent_flag")]
+    public int? HasSentFlag { get; set; }
+
+    [JsonPropertyName("archived_flag")]
+    public int? ArchivedFlag { get; set; }
+
+    [JsonPropertyName("shared_flag")]
+    public int? SharedFlag { get; set; }
+
+    [JsonPropertyName("external_deleted_flag")]
+    public int? ExternalDeletedFlag { get; set; }
+
+    [JsonPropertyName("first_message_to_me_flag")]
+    public int? FirstMessageToMeFlag { get; set; }
+
+    [JsonPropertyName("all_messages_sent_flag")]
+    public int? AllMessagesSentFlag { get; set; }
+
+    [JsonPropertyName("last_message_timestamp")]
+    public string? LastMessageTimestamp { get; set; }
+
+    [JsonPropertyName("first_message_timestamp")]
+    public string? FirstMessageTimestamp { get; set; }
+
+    [JsonPropertyName("last_message_sent_timestamp")]
+    public string? LastMessageSentTimestamp { get; set; }
+
+    [JsonPropertyName("last_message_received_timestamp")]
+    public string? LastMessageReceivedTimestamp { get; set; }
+
+    [JsonPropertyName("add_time")]
+    public string? AddTime { get; set; }
+
+    [JsonPropertyName("update_time")]
+    public string? UpdateTime { get; set; }
+
+    [JsonPropertyName("deal_id")]
+    public int? DealId { get; set; }
+
+    [JsonPropertyName("deal_status")]
+    public string? DealStatus { get; set; }
+
+    [JsonPropertyName("lead_id")]
+    public string? LeadId { get; set; }
+}
+
+/// <summary>
 /// Pipedrive Email Template model
 /// </summary>
 public sealed class EmailTemplate
@@ -799,6 +1054,17 @@ public sealed class OrganizationField : BaseField
 [JsonSerializable(typeof(List<EmailTemplate>))]
 [JsonSerializable(typeof(PipedriveResponse<EmailTemplate>))]
 [JsonSerializable(typeof(PipedriveResponse<List<EmailTemplate>>))]
+[JsonSerializable(typeof(MailParty))]
+[JsonSerializable(typeof(List<MailParty>))]
+[JsonSerializable(typeof(MailMessage))]
+[JsonSerializable(typeof(List<MailMessage>))]
+[JsonSerializable(typeof(PipedriveResponse<MailMessage>))]
+[JsonSerializable(typeof(PipedriveResponse<List<MailMessage>>))]
+[JsonSerializable(typeof(MailThreadParties))]
+[JsonSerializable(typeof(MailThread))]
+[JsonSerializable(typeof(List<MailThread>))]
+[JsonSerializable(typeof(PipedriveResponse<MailThread>))]
+[JsonSerializable(typeof(PipedriveResponse<List<MailThread>>))]
 internal partial class ApiJsonContext : JsonSerializerContext
 {
 }

--- a/src/PipedriveCLI/Program.cs
+++ b/src/PipedriveCLI/Program.cs
@@ -62,6 +62,9 @@ public static class Program
         // Add email templates command
         rootCommand.AddCommand(TemplatesCommands.CreateTemplatesCommand(apiClient));
 
+        // Add emails command (email history and conversations)
+        rootCommand.AddCommand(EmailsCommands.CreateEmailsCommand(apiClient));
+
         // Add update command
         rootCommand.AddCommand(UpdateCommands.CreateUpdateCommand());
 

--- a/src/PipedriveCLI/Services/PipedriveApiClient.cs
+++ b/src/PipedriveCLI/Services/PipedriveApiClient.cs
@@ -676,6 +676,89 @@ public sealed class PipedriveApiClient : IDisposable
 
     #endregion
 
+    #region Mail Messages Operations
+
+    /// <summary>
+    /// Gets mail messages for a deal
+    /// </summary>
+    public async Task<PipedriveResponse<List<MailMessage>>?> GetMailMessagesForDealAsync(int dealId, int? limit = null, int? start = null)
+    {
+        var queryParams = new Dictionary<string, string>();
+        if (limit.HasValue) queryParams["limit"] = limit.Value.ToString();
+        if (start.HasValue) queryParams["start"] = start.Value.ToString();
+
+        var jsonResponse = await GetAsync($"deals/{dealId}/mailMessages", queryParams);
+        return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseListMailMessage);
+    }
+
+    /// <summary>
+    /// Gets mail messages for a person
+    /// </summary>
+    public async Task<PipedriveResponse<List<MailMessage>>?> GetMailMessagesForPersonAsync(int personId, int? limit = null, int? start = null)
+    {
+        var queryParams = new Dictionary<string, string>();
+        if (limit.HasValue) queryParams["limit"] = limit.Value.ToString();
+        if (start.HasValue) queryParams["start"] = start.Value.ToString();
+
+        var jsonResponse = await GetAsync($"persons/{personId}/mailMessages", queryParams);
+        return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseListMailMessage);
+    }
+
+    /// <summary>
+    /// Gets a specific mail message by ID
+    /// </summary>
+    /// <param name="id">The mail message ID</param>
+    /// <param name="includeBody">Whether to include the full email body</param>
+    public async Task<PipedriveResponse<MailMessage>?> GetMailMessageByIdAsync(int id, bool includeBody = false)
+    {
+        var queryParams = new Dictionary<string, string>();
+        if (includeBody) queryParams["include_body"] = "1";
+
+        var jsonResponse = await GetAsync($"mailbox/mailMessages/{id}", queryParams);
+        return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseMailMessage);
+    }
+
+    #endregion
+
+    #region Mail Threads Operations
+
+    /// <summary>
+    /// Gets mail threads with optional folder filter
+    /// </summary>
+    /// <param name="folder">Filter by folder: inbox, drafts, sent, archive</param>
+    /// <param name="limit">Number of threads to return</param>
+    /// <param name="start">Pagination start</param>
+    public async Task<PipedriveResponse<List<MailThread>>?> GetMailThreadsAsync(string? folder = null, int? limit = null, int? start = null)
+    {
+        var queryParams = new Dictionary<string, string>();
+        if (!string.IsNullOrWhiteSpace(folder)) queryParams["folder"] = folder;
+        if (limit.HasValue) queryParams["limit"] = limit.Value.ToString();
+        if (start.HasValue) queryParams["start"] = start.Value.ToString();
+
+        var jsonResponse = await GetAsync("mailbox/mailThreads", queryParams);
+        return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseListMailThread);
+    }
+
+    /// <summary>
+    /// Gets a specific mail thread by ID
+    /// </summary>
+    public async Task<PipedriveResponse<MailThread>?> GetMailThreadByIdAsync(int id)
+    {
+        var jsonResponse = await GetAsync($"mailbox/mailThreads/{id}");
+        return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseMailThread);
+    }
+
+    /// <summary>
+    /// Gets all mail messages in a thread
+    /// </summary>
+    public async Task<PipedriveResponse<List<MailMessage>>?> GetMailThreadMessagesAsync(int threadId)
+    {
+        var jsonResponse = await GetAsync($"mailbox/mailThreads/{threadId}/mailMessages");
+        return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseListMailMessage);
+    }
+
+    #endregion
+
     /// <summary>
     /// Tests the API connection by making a simple request
     /// </summary>


### PR DESCRIPTION
## Summary

Implements GitHub issue #51 - adds comprehensive email viewing capabilities to the CLI, enabling LLM agents and humans to understand prior email context before reaching out to contacts.

- Add `emails list-for-deal` command to list emails associated with a deal
- Add `emails list-for-person` command to list emails for a person  
- Add `emails get` command with `--include-body` option to view full email content
- Add `emails threads` command with folder filtering (inbox/sent/drafts/archive)
- Add `emails thread` command to view thread details
- Add `emails thread-messages` command to get all messages in a thread

## API Endpoints Implemented

| CLI Command | API Endpoint | Cost |
|-------------|--------------|------|
| `emails list-for-deal` | `GET /deals/{id}/mailMessages` | 20 |
| `emails list-for-person` | `GET /persons/{id}/mailMessages` | 20 |
| `emails get` | `GET /mailbox/mailMessages/{id}` | 2 |
| `emails threads` | `GET /mailbox/mailThreads` | 20 |
| `emails thread` | `GET /mailbox/mailThreads/{id}` | 20 |
| `emails thread-messages` | `GET /mailbox/mailThreads/{id}/mailMessages` | 20 |

## Changes

- Added new data models: `MailParty`, `MailMessage`, `MailThreadParties`, `MailThread`
- Added 6 new API client methods in `PipedriveApiClient.cs`
- Created `EmailsCommands.cs` with all subcommands and display formatting
- Updated README with documentation and example workflow
- Added 17 new unit tests for JSON serialization

## Test plan

- [x] All 104 unit tests pass (87 existing + 17 new)
- [x] Build succeeds with 0 warnings
- [x] Help commands work correctly (`pipedrive emails --help`)
- [ ] Manual testing with live Pipedrive account

Closes #51