### PR TITLE
Fix email list-for-deal and list-for-person JSON parsing

### DIFF
--- a/src/PipedriveCLI.Tests/MailMessagesApiClientTests.cs
+++ b/src/PipedriveCLI.Tests/MailMessagesApiClientTests.cs
@@ -835,4 +835,212 @@ public class MailMessagesApiClientTests
     }
 
     #endregion
+
+    #region MailMessageWrapper Tests (Deal/Person Mail Messages)
+
+    /// <summary>
+    /// Test that MailMessageWrapper correctly deserializes the nested structure
+    /// returned by deals/{id}/mailMessages and persons/{id}/mailMessages endpoints
+    /// </summary>
+    [Fact]
+    public void MailMessageWrapper_Deserialization_DealMailMessages()
+    {
+        // Arrange - This is the actual structure returned by deals/{id}/mailMessages
+        var json = """
+        {
+            "success": true,
+            "data": [
+                {
+                    "object": "mailMessage",
+                    "timestamp": "2025-12-02 17:16:53",
+                    "data": {
+                        "id": 637668,
+                        "from": [
+                            {
+                                "id": 28420,
+                                "email_address": "gregorius@example.com",
+                                "name": "Gregorius Soedharmo",
+                                "linked_person_id": 1146,
+                                "linked_person_name": "Gregorius Soedharmo"
+                            }
+                        ],
+                        "to": [
+                            {
+                                "id": 8629,
+                                "email_address": "jay@example.com",
+                                "name": "Jay DeBoer",
+                                "linked_person_id": 110,
+                                "linked_person_name": "Jay DeBoer"
+                            }
+                        ],
+                        "cc": [],
+                        "bcc": [],
+                        "subject": "Discord discussion follow-up",
+                        "snippet": "Hi Jay, I'm Gregorius, part of the team...",
+                        "mail_thread_id": 119048,
+                        "read_flag": 1,
+                        "sent_flag": 0,
+                        "message_time": "2025-12-02T17:16:53.000Z",
+                        "has_attachments_flag": 0,
+                        "deal_id": 1604
+                    }
+                },
+                {
+                    "object": "mailMessage",
+                    "timestamp": "2025-09-22 11:19:00",
+                    "data": {
+                        "id": 633160,
+                        "from": [
+                            {
+                                "id": 5,
+                                "email_address": "aaron@example.com",
+                                "name": "Aaron Stannard"
+                            }
+                        ],
+                        "to": [
+                            {
+                                "id": 8629,
+                                "email_address": "nate@example.com",
+                                "name": "Nate Dahlin"
+                            }
+                        ],
+                        "subject": "Re: Can we help you with your project?",
+                        "snippet": "Hi Nate, Yeah this makes sense to me...",
+                        "mail_thread_id": 115000,
+                        "read_flag": 1,
+                        "sent_flag": 1,
+                        "message_time": "2025-09-22T11:19:00.000Z",
+                        "has_attachments_flag": 0,
+                        "deal_id": 1604
+                    }
+                }
+            ],
+            "additional_data": {
+                "pagination": {
+                    "start": 0,
+                    "limit": 2,
+                    "more_items_in_collection": true,
+                    "next_start": 2
+                }
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseListMailMessageWrapper);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Equal(2, response.Data.Count);
+
+        // First wrapper
+        var wrapper1 = response.Data[0];
+        Assert.Equal("mailMessage", wrapper1.ObjectType);
+        Assert.Equal("2025-12-02 17:16:53", wrapper1.Timestamp);
+        Assert.NotNull(wrapper1.Data);
+        Assert.Equal(637668, wrapper1.Data.Id);
+        Assert.Equal("Discord discussion follow-up", wrapper1.Data.Subject);
+        Assert.NotNull(wrapper1.Data.From);
+        Assert.Single(wrapper1.Data.From);
+        Assert.Equal("gregorius@example.com", wrapper1.Data.From[0].EmailAddress);
+        Assert.Equal("Gregorius Soedharmo", wrapper1.Data.From[0].Name);
+        Assert.Equal(1604, wrapper1.Data.DealId);
+
+        // Second wrapper
+        var wrapper2 = response.Data[1];
+        Assert.Equal("mailMessage", wrapper2.ObjectType);
+        Assert.NotNull(wrapper2.Data);
+        Assert.Equal(633160, wrapper2.Data.Id);
+        Assert.Equal("Re: Can we help you with your project?", wrapper2.Data.Subject);
+        Assert.Equal(1, wrapper2.Data.SentFlag);
+
+        // Pagination
+        Assert.NotNull(response.AdditionalData?.Pagination);
+        Assert.Equal(0, response.AdditionalData.Pagination.Start);
+        Assert.Equal(2, response.AdditionalData.Pagination.Limit);
+        Assert.True(response.AdditionalData.Pagination.MoreItemsInCollection);
+    }
+
+    /// <summary>
+    /// Test extracting MailMessage objects from wrapper list (simulates what EmailsCommands does)
+    /// </summary>
+    [Fact]
+    public void MailMessageWrapper_ExtractInnerMessages()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": true,
+            "data": [
+                {
+                    "object": "mailMessage",
+                    "timestamp": "2025-12-02 10:00:00",
+                    "data": {
+                        "id": 100,
+                        "subject": "First email",
+                        "snippet": "Content 1..."
+                    }
+                },
+                {
+                    "object": "mailMessage",
+                    "timestamp": "2025-12-02 11:00:00",
+                    "data": {
+                        "id": 101,
+                        "subject": "Second email",
+                        "snippet": "Content 2..."
+                    }
+                }
+            ]
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseListMailMessageWrapper);
+        var messages = response!.Data!
+            .Where(w => w.Data != null)
+            .Select(w => w.Data!)
+            .ToList();
+
+        // Assert
+        Assert.Equal(2, messages.Count);
+        Assert.Equal(100, messages[0].Id);
+        Assert.Equal("First email", messages[0].Subject);
+        Assert.Equal(101, messages[1].Id);
+        Assert.Equal("Second email", messages[1].Subject);
+    }
+
+    /// <summary>
+    /// Test handling empty wrapper list
+    /// </summary>
+    [Fact]
+    public void MailMessageWrapper_Deserialization_EmptyList()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": true,
+            "data": [],
+            "additional_data": {
+                "pagination": {
+                    "start": 0,
+                    "limit": 50,
+                    "more_items_in_collection": false
+                }
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseListMailMessageWrapper);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Empty(response.Data);
+    }
+
+    #endregion
 }

--- a/src/PipedriveCLI/Commands/EmailsCommands.cs
+++ b/src/PipedriveCLI/Commands/EmailsCommands.cs
@@ -67,7 +67,12 @@ public static class EmailsCommands
                         if (response?.Success == true && response.Data != null)
                         {
                             ctx.Status("Formatting results...");
-                            DisplayMailMessageList(response.Data, response.AdditionalData?.Pagination);
+                            // Extract inner MailMessage objects from the wrapper structure
+                            var messages = response.Data
+                                .Where(w => w.Data != null)
+                                .Select(w => w.Data!)
+                                .ToList();
+                            DisplayMailMessageList(messages, response.AdditionalData?.Pagination);
                         }
                         else
                         {
@@ -122,7 +127,12 @@ public static class EmailsCommands
                         if (response?.Success == true && response.Data != null)
                         {
                             ctx.Status("Formatting results...");
-                            DisplayMailMessageList(response.Data, response.AdditionalData?.Pagination);
+                            // Extract inner MailMessage objects from the wrapper structure
+                            var messages = response.Data
+                                .Where(w => w.Data != null)
+                                .Select(w => w.Data!)
+                                .ToList();
+                            DisplayMailMessageList(messages, response.AdditionalData?.Pagination);
                         }
                         else
                         {

--- a/src/PipedriveCLI/Models/ApiModels.cs
+++ b/src/PipedriveCLI/Models/ApiModels.cs
@@ -928,6 +928,22 @@ public sealed class MailMessage
 }
 
 /// <summary>
+/// Wrapper object returned by deals/{id}/mailMessages and persons/{id}/mailMessages endpoints.
+/// These endpoints return mail messages in a nested structure with object type and timestamp.
+/// </summary>
+public sealed class MailMessageWrapper
+{
+    [JsonPropertyName("object")]
+    public string? ObjectType { get; set; }
+
+    [JsonPropertyName("timestamp")]
+    public string? Timestamp { get; set; }
+
+    [JsonPropertyName("data")]
+    public MailMessage? Data { get; set; }
+}
+
+/// <summary>
 /// Parties information for a mail thread
 /// </summary>
 public sealed class MailThreadParties
@@ -1233,6 +1249,9 @@ public sealed class OrganizationField : BaseField
 [JsonSerializable(typeof(List<MailMessage>))]
 [JsonSerializable(typeof(PipedriveResponse<MailMessage>))]
 [JsonSerializable(typeof(PipedriveResponse<List<MailMessage>>))]
+[JsonSerializable(typeof(MailMessageWrapper))]
+[JsonSerializable(typeof(List<MailMessageWrapper>))]
+[JsonSerializable(typeof(PipedriveResponse<List<MailMessageWrapper>>))]
 [JsonSerializable(typeof(MailThreadParties))]
 [JsonSerializable(typeof(MailThread))]
 [JsonSerializable(typeof(List<MailThread>))]

--- a/src/PipedriveCLI/Services/PipedriveApiClient.cs
+++ b/src/PipedriveCLI/Services/PipedriveApiClient.cs
@@ -729,29 +729,31 @@ public sealed class PipedriveApiClient : IDisposable
     #region Mail Messages Operations
 
     /// <summary>
-    /// Gets mail messages for a deal
+    /// Gets mail messages for a deal.
+    /// Note: The deals/{id}/mailMessages endpoint returns a nested structure with wrapper objects.
     /// </summary>
-    public async Task<PipedriveResponse<List<MailMessage>>?> GetMailMessagesForDealAsync(int dealId, int? limit = null, int? start = null)
+    public async Task<PipedriveResponse<List<MailMessageWrapper>>?> GetMailMessagesForDealAsync(int dealId, int? limit = null, int? start = null)
     {
         var queryParams = new Dictionary<string, string>();
         if (limit.HasValue) queryParams["limit"] = limit.Value.ToString();
         if (start.HasValue) queryParams["start"] = start.Value.ToString();
 
         var jsonResponse = await GetAsync($"deals/{dealId}/mailMessages", queryParams);
-        return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseListMailMessage);
+        return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseListMailMessageWrapper);
     }
 
     /// <summary>
-    /// Gets mail messages for a person
+    /// Gets mail messages for a person.
+    /// Note: The persons/{id}/mailMessages endpoint returns a nested structure with wrapper objects.
     /// </summary>
-    public async Task<PipedriveResponse<List<MailMessage>>?> GetMailMessagesForPersonAsync(int personId, int? limit = null, int? start = null)
+    public async Task<PipedriveResponse<List<MailMessageWrapper>>?> GetMailMessagesForPersonAsync(int personId, int? limit = null, int? start = null)
     {
         var queryParams = new Dictionary<string, string>();
         if (limit.HasValue) queryParams["limit"] = limit.Value.ToString();
         if (start.HasValue) queryParams["start"] = start.Value.ToString();
 
         var jsonResponse = await GetAsync($"persons/{personId}/mailMessages", queryParams);
-        return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseListMailMessage);
+        return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseListMailMessageWrapper);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Fixes #56 - The `emails list-for-deal` and `emails list-for-person` commands were returning empty data fields despite finding the correct number of emails.

## Root Cause

The `/v1/deals/{id}/mailMessages` and `/v1/persons/{id}/mailMessages` API endpoints return mail messages in a **nested wrapper structure** that differs from the direct mail message endpoints:

```json
{
  "data": [
    {
      "object": "mailMessage",
      "timestamp": "2025-12-02 17:16:53",
      "data": {
        "id": 637668,
        "from": [...],
        "subject": "...",
        ...
      }
    }
  ]
}
```

The previous implementation expected the direct `MailMessage` structure at the top level of the data array, causing all fields to deserialize as empty/zero.

## Changes

- **New Model**: Added `MailMessageWrapper` class to model the nested structure with `object`, `timestamp`, and inner `data` properties
- **API Client**: Updated `GetMailMessagesForDealAsync` and `GetMailMessagesForPersonAsync` to deserialize the wrapper list
- **Commands**: Updated `EmailsCommands` to extract the inner `MailMessage` objects from the wrapper list
- **Tests**: Added 3 new unit tests for wrapper deserialization

## Test plan

- [x] Build succeeds with no warnings
- [x] All 107 unit tests pass
- [x] Manual test: `pipedrive emails list-for-deal 1604` shows correct data
- [x] Manual test: `pipedrive emails list-for-person 110` shows correct data
- [x] Other email commands (`threads`, `thread`, `thread-messages`, `get`) still work correctly