### PR TITLE
Add --pipeline-id filter to deals list command

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,18 @@
+#### 0.5.2 December 2 2025 ####
+
+This release adds the ability to filter deals by pipeline, making pipeline-specific auditing and cleanup workflows much more efficient.
+
+**New Features**
+
+- **Pipeline Filter for Deals List** ([#58](https://github.com/Aaronontheweb/pipedrive-cli/issues/58))
+  - Added `--pipeline-id` / `-p` option to `pipedrive deals list` command
+  - Filter deals to show only those in a specific pipeline
+  - Uses native Pipedrive API filtering for efficient server-side results
+  - Combines with existing `--status` filter for precise queries
+  - Example: `pipedrive deals list --pipeline-id 15 --status open`
+
+---
+
 #### 0.5.0 December 2 2025 ####
 
 This release adds comprehensive email management capabilities, Smart BCC field support, and fixes critical search API bugs.

--- a/src/PipedriveCLI/Commands/DealsCommands.cs
+++ b/src/PipedriveCLI/Commands/DealsCommands.cs
@@ -50,11 +50,16 @@ public static class DealsCommands
             description: "Filter by status (open, won, lost, deleted, all_not_deleted)",
             getDefaultValue: () => "open");
 
+        var pipelineIdOption = new Option<int?>(
+            aliases: new[] { "--pipeline-id", "-p" },
+            description: "Filter by pipeline ID");
+
         listCommand.AddOption(limitOption);
         listCommand.AddOption(startOption);
         listCommand.AddOption(statusOption);
+        listCommand.AddOption(pipelineIdOption);
 
-        listCommand.SetHandler(async (limit, start, status) =>
+        listCommand.SetHandler(async (limit, start, status, pipelineId) =>
         {
             try
             {
@@ -66,7 +71,7 @@ public static class DealsCommands
                         ctx.Spinner(Spinner.Known.Dots);
                         ctx.SpinnerStyle(Style.Parse("green"));
 
-                        var response = await apiClient.GetDealsAsync(limit, start, status);
+                        var response = await apiClient.GetDealsAsync(limit, start, status, pipelineId);
 
                         if (response?.Success == true && response.Data != null)
                         {
@@ -122,7 +127,7 @@ public static class DealsCommands
             {
                 AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
             }
-        }, limitOption, startOption, statusOption);
+        }, limitOption, startOption, statusOption, pipelineIdOption);
 
         return listCommand;
     }

--- a/src/PipedriveCLI/Services/PipedriveApiClient.cs
+++ b/src/PipedriveCLI/Services/PipedriveApiClient.cs
@@ -239,12 +239,13 @@ public sealed class PipedriveApiClient : IDisposable
     /// <summary>
     /// Gets all deals
     /// </summary>
-    public async Task<PipedriveResponse<List<Deal>>?> GetDealsAsync(int? limit = null, int? start = null, string? status = null)
+    public async Task<PipedriveResponse<List<Deal>>?> GetDealsAsync(int? limit = null, int? start = null, string? status = null, int? pipelineId = null)
     {
         var queryParams = new Dictionary<string, string>();
         if (limit.HasValue) queryParams["limit"] = limit.Value.ToString();
         if (start.HasValue) queryParams["start"] = start.Value.ToString();
         if (!string.IsNullOrWhiteSpace(status)) queryParams["status"] = status;
+        if (pipelineId.HasValue) queryParams["pipeline_id"] = pipelineId.Value.ToString();
 
         var jsonResponse = await GetAsync("deals", queryParams);
         return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseListDeal);


### PR DESCRIPTION
## Summary
- Add `--pipeline-id` / `-p` option to `pipedrive deals list` command
- Filter deals to show only those in a specific pipeline
- Uses native Pipedrive API filtering for efficient server-side results

## Test plan
- [x] Tested locally with live credentials
- [x] Verified `pipedrive deals list --pipeline-id 15` returns only deals from pipeline 15
- [x] Verified combining with `--status` filter works correctly

Closes #58