### PR TITLE
Add --lead-id support to activities create command

### DIFF
--- a/src/PipedriveCLI/Commands/ActivitiesCommands.cs
+++ b/src/PipedriveCLI/Commands/ActivitiesCommands.cs
@@ -230,6 +230,10 @@ public static class ActivitiesCommands
             aliases: new[] { "--org-id", "-o" },
             description: "Associated organization ID");
 
+        var leadIdOption = new Option<string?>(
+            aliases: new[] { "--lead-id", "-l" },
+            description: "Associated lead ID (UUID format)");
+
         var noteOption = new Option<string?>(
             aliases: new[] { "--note", "-n" },
             description: "Activity note");
@@ -244,11 +248,22 @@ public static class ActivitiesCommands
         createCommand.AddOption(dealIdOption);
         createCommand.AddOption(personIdOption);
         createCommand.AddOption(orgIdOption);
+        createCommand.AddOption(leadIdOption);
         createCommand.AddOption(noteOption);
         createCommand.AddOption(userIdOption);
 
-        createCommand.SetHandler(async (subject, type, dueDate, dealId, personId, orgId, note, userId) =>
+        createCommand.SetHandler(async context =>
         {
+            var subject = context.ParseResult.GetValueForOption(subjectOption)!;
+            var type = context.ParseResult.GetValueForOption(typeOption)!;
+            var dueDate = context.ParseResult.GetValueForOption(dueDateOption)!;
+            var dealId = context.ParseResult.GetValueForOption(dealIdOption);
+            var personId = context.ParseResult.GetValueForOption(personIdOption);
+            var orgId = context.ParseResult.GetValueForOption(orgIdOption);
+            var leadId = context.ParseResult.GetValueForOption(leadIdOption);
+            var note = context.ParseResult.GetValueForOption(noteOption);
+            var userId = context.ParseResult.GetValueForOption(userIdOption);
+
             try
             {
                 await apiClient.InitializeAsync();
@@ -261,6 +276,7 @@ public static class ActivitiesCommands
                     DealId = dealId,
                     PersonId = personId,
                     OrgId = orgId,
+                    LeadId = leadId,
                     Note = note,
                     UserId = userId,
                     Done = false
@@ -290,7 +306,7 @@ public static class ActivitiesCommands
             {
                 AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
             }
-        }, subjectOption, typeOption, dueDateOption, dealIdOption, personIdOption, orgIdOption, noteOption, userIdOption);
+        });
 
         return createCommand;
     }

--- a/src/PipedriveCLI/Models/ApiModels.cs
+++ b/src/PipedriveCLI/Models/ApiModels.cs
@@ -653,6 +653,9 @@ public sealed class Activity
     [JsonConverter(typeof(PipedriveReferenceConverter))]
     public int? OrgId { get; set; }
 
+    [JsonPropertyName("lead_id")]
+    public string? LeadId { get; set; }
+
     [JsonPropertyName("note")]
     public string? Note { get; set; }
 


### PR DESCRIPTION
## Summary
Closes #65

Activities can now be associated with leads when created using the `--lead-id` option, matching the Pipedrive API's support for the `lead_id` field.

## Changes
- Added `LeadId` property (string/UUID) to the `Activity` model in `ApiModels.cs`
- Added `--lead-id` / `-l` option to the `activities create` command
- Refactored handler to use `InvocationContext` to support more than 8 parameters

## Usage Example
```bash
pipedrive activities create --subject "Follow-up" --type email --due-date "2025-12-09" --lead-id "e126ec80-cfff-11f0-8c59-fd43bfd483d9"
```

## Test plan
- [x] Build succeeds
- [x] All 107 existing tests pass
- [x] Help output shows new `--lead-id` option correctly