### PR TITLE
Add commands to manage deal participants

### DIFF
--- a/src/PipedriveCLI/Commands/DealsCommands.cs
+++ b/src/PipedriveCLI/Commands/DealsCommands.cs
@@ -26,6 +26,9 @@ public static class DealsCommands
         dealsCommand.AddCommand(CreateUpdateCommand(apiClient));
         dealsCommand.AddCommand(CreateDeleteCommand(apiClient));
         dealsCommand.AddCommand(CreateMergeCommand(apiClient));
+        dealsCommand.AddCommand(CreateParticipantsCommand(apiClient));
+        dealsCommand.AddCommand(CreateAddParticipantCommand(apiClient));
+        dealsCommand.AddCommand(CreateRemoveParticipantCommand(apiClient));
 
         return dealsCommand;
     }
@@ -607,5 +610,181 @@ public static class DealsCommands
             return $"{input} 12:00:00";
         }
         return input;
+    }
+
+    /// <summary>
+    /// Creates the 'deals participants' command to list deal participants
+    /// </summary>
+    private static Command CreateParticipantsCommand(PipedriveApiClient apiClient)
+    {
+        var participantsCommand = new Command("participants", "List participants of a deal");
+
+        var dealIdArgument = new Argument<int>("deal-id", "Deal ID");
+        participantsCommand.AddArgument(dealIdArgument);
+
+        var limitOption = new Option<int?>(
+            aliases: new[] { "--limit", "-l" },
+            description: "Number of participants to return (default: 100)");
+
+        participantsCommand.AddOption(limitOption);
+
+        participantsCommand.SetHandler(async (dealId, limit) =>
+        {
+            try
+            {
+                await apiClient.InitializeAsync();
+
+                var response = await AnsiConsole.Status()
+                    .StartAsync($"Fetching participants for deal {dealId}...", async ctx =>
+                    {
+                        ctx.Spinner(Spinner.Known.Dots);
+                        ctx.SpinnerStyle(Style.Parse("green"));
+                        return await apiClient.GetDealParticipantsAsync(dealId, limit);
+                    });
+
+                if (response?.Success == true && response.Data != null)
+                {
+                    if (response.Data.Count == 0)
+                    {
+                        AnsiConsole.MarkupLine("[yellow]No participants found for this deal[/]");
+                        return;
+                    }
+
+                    var table = new Table();
+                    table.AddColumn("ID");
+                    table.AddColumn("Person ID");
+                    table.AddColumn("Name");
+                    table.AddColumn("Email");
+                    table.AddColumn("Added");
+
+                    foreach (var participant in response.Data)
+                    {
+                        var email = participant.Person?.Email?.FirstOrDefault()?.Value ?? "";
+                        table.AddRow(
+                            participant.Id.ToString(),
+                            participant.PersonId.ToString(),
+                            Markup.Escape(participant.Person?.Name ?? ""),
+                            Markup.Escape(email),
+                            Markup.Escape(participant.AddTime ?? ""));
+                    }
+
+                    AnsiConsole.Write(table);
+                    AnsiConsole.MarkupLine($"[dim]Total: {response.Data.Count} participant(s)[/]");
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine($"[red]✗[/] Failed to get participants: {Markup.Escape(response?.Error ?? "Unknown error")}");
+                }
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
+            }
+        }, dealIdArgument, limitOption);
+
+        return participantsCommand;
+    }
+
+    /// <summary>
+    /// Creates the 'deals add-participant' command
+    /// </summary>
+    private static Command CreateAddParticipantCommand(PipedriveApiClient apiClient)
+    {
+        var addParticipantCommand = new Command("add-participant", "Add a participant to a deal");
+
+        var dealIdArgument = new Argument<int>("deal-id", "Deal ID");
+        addParticipantCommand.AddArgument(dealIdArgument);
+
+        var personIdOption = new Option<int>(
+            aliases: new[] { "--person-id", "-p" },
+            description: "Person ID to add as participant")
+        { IsRequired = true };
+
+        addParticipantCommand.AddOption(personIdOption);
+
+        addParticipantCommand.SetHandler(async (dealId, personId) =>
+        {
+            try
+            {
+                await apiClient.InitializeAsync();
+
+                var response = await AnsiConsole.Status()
+                    .StartAsync($"Adding person {personId} to deal {dealId}...", async ctx =>
+                    {
+                        ctx.Spinner(Spinner.Known.Dots);
+                        ctx.SpinnerStyle(Style.Parse("green"));
+                        return await apiClient.AddDealParticipantAsync(dealId, personId);
+                    });
+
+                if (response?.Success == true && response.Data != null)
+                {
+                    AnsiConsole.MarkupLine($"[green]✓[/] Participant added successfully");
+                    AnsiConsole.MarkupLine($"[dim]Participant ID:[/] {response.Data.Id}");
+                    if (response.Data.Person != null)
+                    {
+                        AnsiConsole.MarkupLine($"[dim]Person:[/] {Markup.Escape(response.Data.Person.Name ?? "")}");
+                    }
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine($"[red]✗[/] Failed to add participant: {Markup.Escape(response?.Error ?? "Unknown error")}");
+                }
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
+            }
+        }, dealIdArgument, personIdOption);
+
+        return addParticipantCommand;
+    }
+
+    /// <summary>
+    /// Creates the 'deals remove-participant' command
+    /// </summary>
+    private static Command CreateRemoveParticipantCommand(PipedriveApiClient apiClient)
+    {
+        var removeParticipantCommand = new Command("remove-participant", "Remove a participant from a deal");
+
+        var dealIdArgument = new Argument<int>("deal-id", "Deal ID");
+        removeParticipantCommand.AddArgument(dealIdArgument);
+
+        var participantIdOption = new Option<int>(
+            aliases: new[] { "--participant-id", "-p" },
+            description: "Participant ID to remove (use 'deals participants' to find IDs)")
+        { IsRequired = true };
+
+        removeParticipantCommand.AddOption(participantIdOption);
+
+        removeParticipantCommand.SetHandler(async (dealId, participantId) =>
+        {
+            try
+            {
+                await apiClient.InitializeAsync();
+
+                var success = await AnsiConsole.Status()
+                    .StartAsync($"Removing participant {participantId} from deal {dealId}...", async ctx =>
+                    {
+                        ctx.Spinner(Spinner.Known.Dots);
+                        ctx.SpinnerStyle(Style.Parse("green"));
+                        return await apiClient.RemoveDealParticipantAsync(dealId, participantId);
+                    });
+
+                if (success)
+                {
+                    AnsiConsole.MarkupLine($"[green]✓[/] Participant removed successfully");
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine($"[red]✗[/] Failed to remove participant");
+                }
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
+            }
+        }, dealIdArgument, participantIdOption);
+
+        return removeParticipantCommand;
     }
 }

--- a/src/PipedriveCLI/Models/ApiModels.cs
+++ b/src/PipedriveCLI/Models/ApiModels.cs
@@ -489,6 +489,42 @@ public sealed class Deal
 }
 
 /// <summary>
+/// Pipedrive Deal Participant model - represents a person associated with a deal
+/// </summary>
+public sealed class DealParticipant
+{
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    [JsonPropertyName("person_id")]
+    public int PersonId { get; set; }
+
+    [JsonPropertyName("deal_id")]
+    public int DealId { get; set; }
+
+    [JsonPropertyName("add_time")]
+    public string? AddTime { get; set; }
+
+    [JsonPropertyName("active_flag")]
+    public bool ActiveFlag { get; set; }
+
+    /// <summary>
+    /// The related person object with full details
+    /// </summary>
+    [JsonPropertyName("person")]
+    public Person? Person { get; set; }
+}
+
+/// <summary>
+/// Request model for adding a participant to a deal
+/// </summary>
+public sealed class AddDealParticipantRequest
+{
+    [JsonPropertyName("person_id")]
+    public int PersonId { get; set; }
+}
+
+/// <summary>
 /// Pipedrive Person (contact) model
 /// </summary>
 public sealed class Person
@@ -1189,6 +1225,8 @@ public sealed class OrganizationField : BaseField
 [JsonSerializable(typeof(PipedriveResponse<PersonSearchData>))]
 [JsonSerializable(typeof(PipedriveResponse<Deal>))]
 [JsonSerializable(typeof(PipedriveResponse<List<Deal>>))]
+[JsonSerializable(typeof(PipedriveResponse<DealParticipant>))]
+[JsonSerializable(typeof(PipedriveResponse<List<DealParticipant>>))]
 [JsonSerializable(typeof(PipedriveResponse<Person>))]
 [JsonSerializable(typeof(PipedriveResponse<List<Person>>))]
 [JsonSerializable(typeof(PipedriveResponse<Organization>))]
@@ -1210,6 +1248,9 @@ public sealed class OrganizationField : BaseField
 [JsonSerializable(typeof(SearchOwner))]
 [JsonSerializable(typeof(SearchOrganizationRef))]
 [JsonSerializable(typeof(Deal))]
+[JsonSerializable(typeof(DealParticipant))]
+[JsonSerializable(typeof(AddDealParticipantRequest))]
+[JsonSerializable(typeof(List<DealParticipant>))]
 [JsonSerializable(typeof(Person))]
 [JsonSerializable(typeof(Organization))]
 [JsonSerializable(typeof(Activity))]

--- a/src/PipedriveCLI/Services/PipedriveApiClient.cs
+++ b/src/PipedriveCLI/Services/PipedriveApiClient.cs
@@ -301,6 +301,38 @@ public sealed class PipedriveApiClient : IDisposable
         return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseDeal);
     }
 
+    /// <summary>
+    /// Gets all participants of a deal
+    /// </summary>
+    public async Task<PipedriveResponse<List<DealParticipant>>?> GetDealParticipantsAsync(int dealId, int? limit = null, int? start = null)
+    {
+        var queryParams = new Dictionary<string, string>();
+        if (limit.HasValue) queryParams["limit"] = limit.Value.ToString();
+        if (start.HasValue) queryParams["start"] = start.Value.ToString();
+
+        var jsonResponse = await GetAsync($"deals/{dealId}/participants", queryParams);
+        return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseListDealParticipant);
+    }
+
+    /// <summary>
+    /// Adds a participant to a deal
+    /// </summary>
+    public async Task<PipedriveResponse<DealParticipant>?> AddDealParticipantAsync(int dealId, int personId)
+    {
+        var request = new AddDealParticipantRequest { PersonId = personId };
+        var jsonData = JsonSerializer.Serialize(request, ApiJsonContext.Default.AddDealParticipantRequest);
+        var jsonResponse = await PostAsync($"deals/{dealId}/participants", jsonData);
+        return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseDealParticipant);
+    }
+
+    /// <summary>
+    /// Removes a participant from a deal
+    /// </summary>
+    public async Task<bool> RemoveDealParticipantAsync(int dealId, int participantId)
+    {
+        return await DeleteAsync($"deals/{dealId}/participants/{participantId}");
+    }
+
     #endregion
 
     #region Activities Operations


### PR DESCRIPTION
## Summary
Closes #67

Adds new subcommands for managing deal participants, allowing users to add and manage additional stakeholders on deals.

## New Commands

```bash
# List participants of a deal
pipedrive deals participants <deal-id>

# Add a participant to a deal
pipedrive deals add-participant <deal-id> --person-id <person-id>

# Remove a participant from a deal
pipedrive deals remove-participant <deal-id> --participant-id <participant-id>
```

## Changes
- Added `DealParticipant` model with person details
- Added `AddDealParticipantRequest` model for API requests
- Added API client methods:
  - `GetDealParticipantsAsync()` - GET /deals/{id}/participants
  - `AddDealParticipantAsync()` - POST /deals/{id}/participants
  - `RemoveDealParticipantAsync()` - DELETE /deals/{id}/participants/{participant_id}
- Added three new subcommands to the `deals` command group
- Added JsonSerializable attributes for AOT compatibility

## Related
Also filed #68 for adding participants support to activities create/update (separate enhancement).

## Test plan
- [x] Build succeeds
- [x] All 107 existing tests pass
- [x] Help output shows new commands correctly