### PR TITLE
Fix DealParticipant JSON deserialization for person_id field

### DIFF
--- a/src/PipedriveCLI/Commands/DealsCommands.cs
+++ b/src/PipedriveCLI/Commands/DealsCommands.cs
@@ -662,7 +662,7 @@ public static class DealsCommands
                         var email = participant.Person?.Email?.FirstOrDefault()?.Value ?? "";
                         table.AddRow(
                             participant.Id.ToString(),
-                            participant.PersonId.ToString(),
+                            participant.PersonId?.ToString() ?? "",
                             Markup.Escape(participant.Person?.Name ?? ""),
                             Markup.Escape(email),
                             Markup.Escape(participant.AddTime ?? ""));

--- a/src/PipedriveCLI/Models/ApiModels.cs
+++ b/src/PipedriveCLI/Models/ApiModels.cs
@@ -497,7 +497,8 @@ public sealed class DealParticipant
     public int Id { get; set; }
 
     [JsonPropertyName("person_id")]
-    public int PersonId { get; set; }
+    [JsonConverter(typeof(PipedriveReferenceConverter))]
+    public int? PersonId { get; set; }
 
     [JsonPropertyName("deal_id")]
     public int DealId { get; set; }


### PR DESCRIPTION
## Summary

- Applied `PipedriveReferenceConverter` to `DealParticipant.PersonId` to handle nested object responses from the Pipedrive API
- The API returns `person_id` as an object with a `value` property, not a simple integer

## Root Cause

The Pipedrive API returns participant data in this format:
```json
{
  "person_id": {
    "active_flag": true,
    "name": "John Doe",
    "email": [...],
    "phone": [...],
    "value": 103
  }
}
```

The CLI was trying to deserialize this as a simple `int`, causing the error:
```
Error: The JSON value could not be converted to System.Int32. Path: $.data[0].person_id
```

## Test plan

- [x] Build succeeds
- [x] All 107 unit tests pass
- [ ] Manual test: `pipedrive deals participants <deal-id>` works with deals that have participants

Fixes #71