### PR TITLE
Add --deal-id, --person-id, --org-id filters to activities list command

### DIFF
--- a/src/PipedriveCLI/Commands/ActivitiesCommands.cs
+++ b/src/PipedriveCLI/Commands/ActivitiesCommands.cs
@@ -48,23 +48,75 @@ public static class ActivitiesCommands
             description: "Filter by done status (true/false, default: false)",
             getDefaultValue: () => false);
 
+        var dealIdOption = new Option<int?>(
+            aliases: new[] { "--deal-id" },
+            description: "Filter activities by deal ID");
+
+        var personIdOption = new Option<int?>(
+            aliases: new[] { "--person-id", "-p" },
+            description: "Filter activities by person ID");
+
+        var orgIdOption = new Option<int?>(
+            aliases: new[] { "--org-id", "-o" },
+            description: "Filter activities by organization ID");
+
         listCommand.AddOption(limitOption);
         listCommand.AddOption(startOption);
         listCommand.AddOption(doneOption);
+        listCommand.AddOption(dealIdOption);
+        listCommand.AddOption(personIdOption);
+        listCommand.AddOption(orgIdOption);
 
-        listCommand.SetHandler(async (limit, start, done) =>
+        listCommand.SetHandler(async context =>
         {
+            var limit = context.ParseResult.GetValueForOption(limitOption);
+            var start = context.ParseResult.GetValueForOption(startOption);
+            var done = context.ParseResult.GetValueForOption(doneOption);
+            var dealId = context.ParseResult.GetValueForOption(dealIdOption);
+            var personId = context.ParseResult.GetValueForOption(personIdOption);
+            var orgId = context.ParseResult.GetValueForOption(orgIdOption);
+
+            // Validate that only one entity filter is used at a time
+            var filterCount = (dealId.HasValue ? 1 : 0) + (personId.HasValue ? 1 : 0) + (orgId.HasValue ? 1 : 0);
+            if (filterCount > 1)
+            {
+                AnsiConsole.MarkupLine("[red]Error:[/] Only one of --deal-id, --person-id, or --org-id can be specified at a time");
+                return;
+            }
+
             try
             {
                 await apiClient.InitializeAsync();
 
+                var statusMessage = dealId.HasValue ? $"Fetching activities for deal {dealId}..."
+                    : personId.HasValue ? $"Fetching activities for person {personId}..."
+                    : orgId.HasValue ? $"Fetching activities for organization {orgId}..."
+                    : "Fetching activities...";
+
                 await AnsiConsole.Status()
-                    .StartAsync("Fetching activities...", async ctx =>
+                    .StartAsync(statusMessage, async ctx =>
                     {
                         ctx.Spinner(Spinner.Known.Dots);
                         ctx.SpinnerStyle(Style.Parse("green"));
 
-                        var response = await apiClient.GetActivitiesAsync(limit, start, done);
+                        PipedriveResponse<List<Activity>>? response;
+
+                        if (dealId.HasValue)
+                        {
+                            response = await apiClient.GetDealActivitiesAsync(dealId.Value, limit, start, done);
+                        }
+                        else if (personId.HasValue)
+                        {
+                            response = await apiClient.GetPersonActivitiesAsync(personId.Value, limit, start, done);
+                        }
+                        else if (orgId.HasValue)
+                        {
+                            response = await apiClient.GetOrganizationActivitiesAsync(orgId.Value, limit, start, done);
+                        }
+                        else
+                        {
+                            response = await apiClient.GetActivitiesAsync(limit, start, done);
+                        }
 
                         if (response?.Success == true && response.Data != null)
                         {
@@ -125,7 +177,7 @@ public static class ActivitiesCommands
             {
                 AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
             }
-        }, limitOption, startOption, doneOption);
+        });
 
         return listCommand;
     }

--- a/src/PipedriveCLI/Services/PipedriveApiClient.cs
+++ b/src/PipedriveCLI/Services/PipedriveApiClient.cs
@@ -399,6 +399,48 @@ public sealed class PipedriveApiClient : IDisposable
         return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseActivity);
     }
 
+    /// <summary>
+    /// Gets activities associated with a specific deal
+    /// </summary>
+    public async Task<PipedriveResponse<List<Activity>>?> GetDealActivitiesAsync(int dealId, int? limit = null, int? start = null, bool? done = null)
+    {
+        var queryParams = new Dictionary<string, string>();
+        if (limit.HasValue) queryParams["limit"] = limit.Value.ToString();
+        if (start.HasValue) queryParams["start"] = start.Value.ToString();
+        if (done.HasValue) queryParams["done"] = done.Value ? "1" : "0";
+
+        var jsonResponse = await GetAsync($"deals/{dealId}/activities", queryParams);
+        return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseListActivity);
+    }
+
+    /// <summary>
+    /// Gets activities associated with a specific person
+    /// </summary>
+    public async Task<PipedriveResponse<List<Activity>>?> GetPersonActivitiesAsync(int personId, int? limit = null, int? start = null, bool? done = null)
+    {
+        var queryParams = new Dictionary<string, string>();
+        if (limit.HasValue) queryParams["limit"] = limit.Value.ToString();
+        if (start.HasValue) queryParams["start"] = start.Value.ToString();
+        if (done.HasValue) queryParams["done"] = done.Value ? "1" : "0";
+
+        var jsonResponse = await GetAsync($"persons/{personId}/activities", queryParams);
+        return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseListActivity);
+    }
+
+    /// <summary>
+    /// Gets activities associated with a specific organization
+    /// </summary>
+    public async Task<PipedriveResponse<List<Activity>>?> GetOrganizationActivitiesAsync(int orgId, int? limit = null, int? start = null, bool? done = null)
+    {
+        var queryParams = new Dictionary<string, string>();
+        if (limit.HasValue) queryParams["limit"] = limit.Value.ToString();
+        if (start.HasValue) queryParams["start"] = start.Value.ToString();
+        if (done.HasValue) queryParams["done"] = done.Value ? "1" : "0";
+
+        var jsonResponse = await GetAsync($"organizations/{orgId}/activities", queryParams);
+        return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseListActivity);
+    }
+
     #endregion
 
     #region Notes Operations


### PR DESCRIPTION
## Summary

- Added `--deal-id` filter option to list activities for a specific deal
- Added `--person-id` / `-p` filter option to list activities for a specific person
- Added `--org-id` / `-o` filter option to list activities for a specific organization
- Only one filter can be used at a time (validated with helpful error message)
- Added new API client methods for entity-specific activity endpoints

## Usage

```bash
# List activities for a specific deal
pipedrive activities list --deal-id 1234

# List activities for a specific person
pipedrive activities list --person-id 456

# List activities for a specific organization
pipedrive activities list --org-id 789

# Combine with existing options
pipedrive activities list --deal-id 1234 --done --limit 50
```

## Test plan

- [x] Build succeeds
- [x] All 107 unit tests pass
- [ ] Manual test: `pipedrive activities list --deal-id <id>` returns activities for that deal
- [ ] Manual test: `pipedrive activities list --person-id <id>` returns activities for that person
- [ ] Manual test: `pipedrive activities list --org-id <id>` returns activities for that org
- [ ] Manual test: Using multiple filters shows error message

Fixes #72