### PR TITLE
Add --deal-id, --person-id, --org-id filters to notes list command

### DIFF
--- a/src/PipedriveCLI/Commands/NotesCommands.cs
+++ b/src/PipedriveCLI/Commands/NotesCommands.cs
@@ -42,11 +42,32 @@ public static class NotesCommands
             aliases: new[] { "--start", "-s" },
             description: "Pagination start (default: 0)");
 
+        var dealIdOption = new Option<int?>(
+            aliases: new[] { "--deal-id", "-d" },
+            description: "Filter notes by deal ID");
+
+        var personIdOption = new Option<int?>(
+            aliases: new[] { "--person-id", "-p" },
+            description: "Filter notes by person ID");
+
+        var orgIdOption = new Option<int?>(
+            aliases: new[] { "--org-id", "-o" },
+            description: "Filter notes by organization ID");
+
         listCommand.AddOption(limitOption);
         listCommand.AddOption(startOption);
+        listCommand.AddOption(dealIdOption);
+        listCommand.AddOption(personIdOption);
+        listCommand.AddOption(orgIdOption);
 
-        listCommand.SetHandler(async (limit, start) =>
+        listCommand.SetHandler(async (context) =>
         {
+            var limit = context.ParseResult.GetValueForOption(limitOption);
+            var start = context.ParseResult.GetValueForOption(startOption);
+            var dealId = context.ParseResult.GetValueForOption(dealIdOption);
+            var personId = context.ParseResult.GetValueForOption(personIdOption);
+            var orgId = context.ParseResult.GetValueForOption(orgIdOption);
+
             try
             {
                 await apiClient.InitializeAsync();
@@ -57,56 +78,65 @@ public static class NotesCommands
                         ctx.Spinner(Spinner.Known.Dots);
                         ctx.SpinnerStyle(Style.Parse("green"));
 
-                        var response = await apiClient.GetNotesAsync(limit, start);
+                        var response = await apiClient.GetNotesAsync(limit, start, dealId, personId, orgId);
 
-                        if (response?.Success == true && response.Data != null)
+                        if (response?.Success == true)
                         {
                             ctx.Status("Formatting results...");
 
-                            var table = new Table();
-                            table.Border(TableBorder.Rounded);
-                            table.AddColumn("ID");
-                            table.AddColumn("Content Preview");
-                            table.AddColumn("Deal/Person/Org/Lead");
-                            table.AddColumn("User ID");
-                            table.AddColumn("Added");
+                            var notes = response.Data ?? new List<Note>();
 
-                            foreach (var note in response.Data)
+                            if (notes.Count == 0)
                             {
-                                // Truncate and sanitize content for display
-                                var contentPreview = note.Content ?? "-";
-                                if (contentPreview.Length > 50)
+                                AnsiConsole.MarkupLine("[yellow]No notes found[/]");
+                            }
+                            else
+                            {
+                                var table = new Table();
+                                table.Border(TableBorder.Rounded);
+                                table.AddColumn("ID");
+                                table.AddColumn("Content Preview");
+                                table.AddColumn("Deal/Person/Org/Lead");
+                                table.AddColumn("User ID");
+                                table.AddColumn("Added");
+
+                                foreach (var note in notes)
                                 {
-                                    contentPreview = contentPreview.Substring(0, 50) + "...";
+                                    // Truncate and sanitize content for display
+                                    var contentPreview = note.Content ?? "-";
+                                    if (contentPreview.Length > 50)
+                                    {
+                                        contentPreview = contentPreview.Substring(0, 50) + "...";
+                                    }
+                                    contentPreview = Markup.Escape(contentPreview.Replace("\n", " ").Replace("\r", ""));
+
+                                    var entityInfo = note.DealId?.ToString()
+                                        ?? note.PersonId?.ToString()
+                                        ?? note.OrgId?.ToString()
+                                        ?? note.LeadId
+                                        ?? note.ProjectId?.ToString()
+                                        ?? "-";
+
+                                    table.AddRow(
+                                        note.Id.ToString(),
+                                        contentPreview,
+                                        entityInfo,
+                                        note.UserId?.ToString() ?? "-",
+                                        note.AddTime ?? "-"
+                                    );
                                 }
-                                contentPreview = Markup.Escape(contentPreview.Replace("\n", " ").Replace("\r", ""));
 
-                                var entityInfo = note.DealId?.ToString()
-                                    ?? note.PersonId?.ToString()
-                                    ?? note.OrgId?.ToString()
-                                    ?? note.LeadId
-                                    ?? note.ProjectId?.ToString()
-                                    ?? "-";
+                                AnsiConsole.Write(table);
 
-                                table.AddRow(
-                                    note.Id.ToString(),
-                                    contentPreview,
-                                    entityInfo,
-                                    note.UserId?.ToString() ?? "-",
-                                    note.AddTime ?? "-"
-                                );
+                                if (response.AdditionalData?.Pagination != null)
+                                {
+                                    var pagination = response.AdditionalData.Pagination;
+                                    AnsiConsole.MarkupLine($"\n[dim]Showing {pagination.Start + 1}-{pagination.Start + notes.Count} " +
+                                        $"| More available: {pagination.MoreItemsInCollection}[/]");
+                                }
                             }
 
-                            AnsiConsole.Write(table);
-
-                            if (response.AdditionalData?.Pagination != null)
-                            {
-                                var pagination = response.AdditionalData.Pagination;
-                                AnsiConsole.MarkupLine($"\n[dim]Showing {pagination.Start + 1}-{pagination.Start + response.Data.Count} " +
-                                    $"| More available: {pagination.MoreItemsInCollection}[/]");
-                            }
-
-                            AnsiConsole.MarkupLine($"\n[green]✓[/] Found {response.Data.Count} note(s)");
+                            AnsiConsole.MarkupLine($"\n[green]✓[/] Found {notes.Count} note(s)");
                         }
                         else
                         {
@@ -118,7 +148,7 @@ public static class NotesCommands
             {
                 AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
             }
-        }, limitOption, startOption);
+        });
 
         return listCommand;
     }

--- a/src/PipedriveCLI/Services/PipedriveApiClient.cs
+++ b/src/PipedriveCLI/Services/PipedriveApiClient.cs
@@ -448,11 +448,14 @@ public sealed class PipedriveApiClient : IDisposable
     /// <summary>
     /// Retrieves all notes with pagination support
     /// </summary>
-    public async Task<PipedriveResponse<List<Note>>?> GetNotesAsync(int? limit = null, int? start = null)
+    public async Task<PipedriveResponse<List<Note>>?> GetNotesAsync(int? limit = null, int? start = null, int? dealId = null, int? personId = null, int? orgId = null)
     {
         var queryParams = new Dictionary<string, string>();
         if (limit.HasValue) queryParams["limit"] = limit.Value.ToString();
         if (start.HasValue) queryParams["start"] = start.Value.ToString();
+        if (dealId.HasValue) queryParams["deal_id"] = dealId.Value.ToString();
+        if (personId.HasValue) queryParams["person_id"] = personId.Value.ToString();
+        if (orgId.HasValue) queryParams["org_id"] = orgId.Value.ToString();
 
         var jsonResponse = await GetAsync("notes", queryParams);
         return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseListNote);


### PR DESCRIPTION
## Summary
- Add filter options to notes list command for filtering by deal, person, or organization
- Update GetNotesAsync API method to support `deal_id`, `person_id`, `org_id` query parameters
- Handle case where API returns null data (no notes found) by showing "No notes found" message instead of error

Fixes #76

## Test plan
- [x] Tested `notes list --deal-id 1` - returns notes for deal 1
- [x] Tested `notes list --person-id 2` - correctly shows "No notes found" when person has no notes
- [x] Tested `notes list --org-id 7` - returns notes for organization 7
- [x] Tested basic `notes list` without filters - still works as expected
- [x] All 107 unit tests pass