### PR TITLE
Add dealFields list command to discover custom field keys

### DIFF
--- a/src/PipedriveCLI/Commands/DealFieldsCommands.cs
+++ b/src/PipedriveCLI/Commands/DealFieldsCommands.cs
@@ -1,0 +1,127 @@
+using System.CommandLine;
+using PipedriveCLI.Services;
+using Spectre.Console;
+
+namespace PipedriveCLI.Commands;
+
+/// <summary>
+/// Commands for managing Pipedrive deal field definitions
+/// </summary>
+public static class DealFieldsCommands
+{
+    /// <summary>
+    /// Creates the root 'dealFields' command with all subcommands
+    /// </summary>
+    public static Command CreateDealFieldsCommand(PipedriveApiClient apiClient)
+    {
+        var dealFieldsCommand = new Command("dealFields", "Manage Pipedrive deal field definitions (discover custom field keys)");
+
+        // Add subcommands
+        dealFieldsCommand.AddCommand(CreateListCommand(apiClient));
+
+        return dealFieldsCommand;
+    }
+
+    /// <summary>
+    /// Creates the 'dealFields list' command
+    /// </summary>
+    private static Command CreateListCommand(PipedriveApiClient apiClient)
+    {
+        var listCommand = new Command("list", "List all deal fields (including custom fields with their keys)");
+
+        var searchOption = new Option<string?>(
+            aliases: new[] { "--search", "-s" },
+            description: "Filter fields by name (case-insensitive)");
+
+        var customOnlyOption = new Option<bool>(
+            aliases: new[] { "--custom-only", "-c" },
+            description: "Only show custom fields (excludes built-in fields)");
+
+        listCommand.AddOption(searchOption);
+        listCommand.AddOption(customOnlyOption);
+
+        listCommand.SetHandler(async (search, customOnly) =>
+        {
+            try
+            {
+                await apiClient.InitializeAsync();
+
+                await AnsiConsole.Status()
+                    .StartAsync("Fetching deal fields...", async ctx =>
+                    {
+                        ctx.Spinner(Spinner.Known.Dots);
+                        ctx.SpinnerStyle(Style.Parse("green"));
+
+                        var response = await apiClient.GetDealFieldsAsync();
+
+                        if (response?.Success == true && response.Data != null)
+                        {
+                            ctx.Status("Formatting results...");
+
+                            var fields = response.Data.AsEnumerable();
+
+                            // Filter by custom only if requested
+                            if (customOnly)
+                            {
+                                fields = fields.Where(f => f.EditFlag == true);
+                            }
+
+                            // Filter by search term if provided
+                            if (!string.IsNullOrWhiteSpace(search))
+                            {
+                                fields = fields.Where(f =>
+                                    f.Name?.Contains(search, StringComparison.OrdinalIgnoreCase) == true);
+                            }
+
+                            var fieldList = fields.ToList();
+
+                            if (fieldList.Count == 0)
+                            {
+                                AnsiConsole.MarkupLine("[yellow]No matching fields found[/]");
+                            }
+                            else
+                            {
+                                var table = new Table();
+                                table.Border(TableBorder.Rounded);
+                                table.AddColumn("ID");
+                                table.AddColumn("Key");
+                                table.AddColumn("Name");
+                                table.AddColumn("Type");
+                                table.AddColumn("Editable");
+                                table.AddColumn("Required");
+
+                                foreach (var field in fieldList)
+                                {
+                                    table.AddRow(
+                                        field.Id?.ToString() ?? "-",
+                                        Markup.Escape(field.Key ?? "-"),
+                                        Markup.Escape(field.Name ?? "-"),
+                                        Markup.Escape(field.FieldType ?? "-"),
+                                        field.EditFlag == true ? "[green]Yes[/]" : "[dim]No[/]",
+                                        field.MandatoryFlag == true ? "[yellow]Yes[/]" : "[dim]No[/]"
+                                    );
+                                }
+
+                                AnsiConsole.Write(table);
+
+                                // Show hint about using keys for custom fields
+                                AnsiConsole.MarkupLine($"\n[green]✓[/] Found {fieldList.Count} field(s)");
+                                AnsiConsole.MarkupLine("[dim]Use the 'Key' value with --custom-fields when updating deals, e.g.:[/]");
+                                AnsiConsole.MarkupLine("[dim]  pipedrive deals update <id> --custom-fields \"<key>=<value>\"[/]");
+                            }
+                        }
+                        else
+                        {
+                            AnsiConsole.MarkupLine($"[red]✗[/] Failed to fetch deal fields: {Markup.Escape(response?.Error ?? "Unknown error")}");
+                        }
+                    });
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
+            }
+        }, searchOption, customOnlyOption);
+
+        return listCommand;
+    }
+}

--- a/src/PipedriveCLI/Models/ApiModels.cs
+++ b/src/PipedriveCLI/Models/ApiModels.cs
@@ -1172,10 +1172,38 @@ public sealed class EmailTemplate
 public sealed class FieldOption
 {
     [JsonPropertyName("id")]
-    public int? Id { get; set; }
+    [JsonConverter(typeof(StringOrIntIdConverter))]
+    public string? Id { get; set; }
 
     [JsonPropertyName("label")]
     public string? Label { get; set; }
+}
+
+/// <summary>
+/// Converter that handles JSON values that can be either a string, integer, or boolean and returns them as string
+/// </summary>
+public sealed class StringOrIntIdConverter : JsonConverter<string?>
+{
+    public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.TokenType switch
+        {
+            JsonTokenType.String => reader.GetString(),
+            JsonTokenType.Number => reader.GetInt64().ToString(),
+            JsonTokenType.True => "true",
+            JsonTokenType.False => "false",
+            JsonTokenType.Null => null,
+            _ => throw new JsonException($"Unexpected token type: {reader.TokenType}")
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, string? value, JsonSerializerOptions options)
+    {
+        if (value != null)
+            writer.WriteStringValue(value);
+        else
+            writer.WriteNullValue();
+    }
 }
 
 /// <summary>
@@ -1199,10 +1227,44 @@ public abstract class BaseField
     public bool? EditFlag { get; set; }
 
     [JsonPropertyName("mandatory_flag")]
+    [JsonConverter(typeof(BoolOrObjectConverter))]
     public bool? MandatoryFlag { get; set; }
 
     [JsonPropertyName("options")]
     public List<FieldOption>? Options { get; set; }
+}
+
+/// <summary>
+/// Converter that handles JSON values that can be either a boolean or an object (treats objects as true)
+/// </summary>
+public sealed class BoolOrObjectConverter : JsonConverter<bool?>
+{
+    public override bool? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.True:
+                return true;
+            case JsonTokenType.False:
+                return false;
+            case JsonTokenType.Null:
+                return null;
+            case JsonTokenType.StartObject:
+                // When mandatory_flag is an object (conditional requirement), treat it as true
+                reader.Skip();
+                return true;
+            default:
+                throw new JsonException($"Unexpected token type: {reader.TokenType}");
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, bool? value, JsonSerializerOptions options)
+    {
+        if (value.HasValue)
+            writer.WriteBooleanValue(value.Value);
+        else
+            writer.WriteNullValue();
+    }
 }
 
 /// <summary>

--- a/src/PipedriveCLI/Program.cs
+++ b/src/PipedriveCLI/Program.cs
@@ -59,6 +59,9 @@ public static class Program
         // Add pipelines command
         rootCommand.AddCommand(PipelinesCommands.CreatePipelinesCommand(apiClient));
 
+        // Add deal fields command
+        rootCommand.AddCommand(DealFieldsCommands.CreateDealFieldsCommand(apiClient));
+
         // Add email templates command
         rootCommand.AddCommand(TemplatesCommands.CreateTemplatesCommand(apiClient));
 


### PR DESCRIPTION
## Summary
- Add new `dealFields` command with `list` subcommand for discovering custom field keys
- Add `--search` option to filter fields by name (case-insensitive)
- Add `--custom-only` option to show only custom/editable fields
- Add `BoolOrObjectConverter` to handle Pipedrive's `mandatory_flag` being either boolean or conditional object
- Add `StringOrIntIdConverter` to handle `FieldOption.Id` being either string or integer
- Display helpful hint about using field keys with `--custom-fields` option

Fixes #79

## Test plan
- [x] Run `pipedrive dealFields list` - shows all deal fields with ID, Key, Name, Type, Editable, Required columns
- [x] Run `pipedrive dealFields list --search "status"` - filters by name
- [x] Run `pipedrive dealFields list --custom-only` - shows only custom fields
- [x] All 107 unit tests pass