### PR TITLE
Add archive/unarchive commands for leads

### DIFF
--- a/src/PipedriveCLI.Tests/LeadsCommandTests.cs
+++ b/src/PipedriveCLI.Tests/LeadsCommandTests.cs
@@ -301,6 +301,95 @@ public class LeadsApiClientTests
     }
 
     /// <summary>
+    /// Test lead with is_archived field (for archive/unarchive functionality)
+    /// </summary>
+    [Fact]
+    public void Lead_Deserialization_HandlesIsArchivedField()
+    {
+        // Arrange - Lead with is_archived field
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "id": "archived-lead",
+                "title": "Archived Lead",
+                "owner_id": null,
+                "person_id": 123,
+                "organization_id": null,
+                "is_archived": true,
+                "was_seen": true,
+                "add_time": "2024-01-01T00:00:00Z",
+                "update_time": "2024-01-01T00:00:00Z"
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseLead);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Equal("archived-lead", response.Data.Id);
+        Assert.True(response.Data.IsArchived);
+    }
+
+    /// <summary>
+    /// Test lead serialization includes is_archived for update operations
+    /// </summary>
+    [Fact]
+    public void Lead_Serialization_IncludesIsArchived()
+    {
+        // Arrange
+        var lead = new Lead
+        {
+            IsArchived = true
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(lead, ApiJsonContext.Default.Lead);
+
+        // Assert - Check for the key and value (allowing for whitespace in pretty-printed JSON)
+        Assert.Contains("is_archived", json);
+        Assert.Contains("true", json);
+    }
+
+    /// <summary>
+    /// Test lead with is_archived = false
+    /// </summary>
+    [Fact]
+    public void Lead_Deserialization_HandlesIsArchivedFalse()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "id": "active-lead",
+                "title": "Active Lead",
+                "owner_id": null,
+                "person_id": 456,
+                "organization_id": null,
+                "is_archived": false,
+                "was_seen": false,
+                "add_time": "2024-01-01T00:00:00Z",
+                "update_time": "2024-01-01T00:00:00Z"
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseLead);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.False(response.Data.IsArchived);
+    }
+
+    /// <summary>
     /// Test that empty list response deserializes correctly
     /// </summary>
     [Fact]

--- a/src/PipedriveCLI/Commands/LeadsCommands.cs
+++ b/src/PipedriveCLI/Commands/LeadsCommands.cs
@@ -24,6 +24,8 @@ public static class LeadsCommands
         leadsCommand.AddCommand(CreateUpdateCommand(apiClient));
         leadsCommand.AddCommand(CreateDeleteCommand(apiClient));
         leadsCommand.AddCommand(CreateSearchCommand(apiClient));
+        leadsCommand.AddCommand(CreateArchiveCommand(apiClient));
+        leadsCommand.AddCommand(CreateUnarchiveCommand(apiClient));
 
         return leadsCommand;
     }
@@ -524,5 +526,93 @@ public static class LeadsCommands
         }, termArgument, limitOption);
 
         return searchCommand;
+    }
+
+    /// <summary>
+    /// Creates the 'leads archive' command
+    /// </summary>
+    private static Command CreateArchiveCommand(PipedriveApiClient apiClient)
+    {
+        var archiveCommand = new Command("archive", "Archive a lead");
+
+        var idArgument = new Argument<string>("id", "Lead ID");
+        archiveCommand.AddArgument(idArgument);
+
+        archiveCommand.SetHandler(async (id) =>
+        {
+            try
+            {
+                await apiClient.InitializeAsync();
+
+                var lead = new Lead { IsArchived = true };
+
+                var response = await AnsiConsole.Status()
+                    .StartAsync($"Archiving lead {id}...", async ctx =>
+                    {
+                        ctx.Spinner(Spinner.Known.Dots);
+                        ctx.SpinnerStyle(Style.Parse("green"));
+                        return await apiClient.UpdateLeadAsync(id, lead);
+                    });
+
+                if (response?.Success == true)
+                {
+                    AnsiConsole.MarkupLine($"[green]✓[/] Lead {id} archived successfully");
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine($"[red]✗[/] Failed to archive lead: {Markup.Escape(response?.Error ?? "Unknown error")}");
+                }
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
+            }
+        }, idArgument);
+
+        return archiveCommand;
+    }
+
+    /// <summary>
+    /// Creates the 'leads unarchive' command
+    /// </summary>
+    private static Command CreateUnarchiveCommand(PipedriveApiClient apiClient)
+    {
+        var unarchiveCommand = new Command("unarchive", "Unarchive a lead");
+
+        var idArgument = new Argument<string>("id", "Lead ID");
+        unarchiveCommand.AddArgument(idArgument);
+
+        unarchiveCommand.SetHandler(async (id) =>
+        {
+            try
+            {
+                await apiClient.InitializeAsync();
+
+                var lead = new Lead { IsArchived = false };
+
+                var response = await AnsiConsole.Status()
+                    .StartAsync($"Unarchiving lead {id}...", async ctx =>
+                    {
+                        ctx.Spinner(Spinner.Known.Dots);
+                        ctx.SpinnerStyle(Style.Parse("green"));
+                        return await apiClient.UpdateLeadAsync(id, lead);
+                    });
+
+                if (response?.Success == true)
+                {
+                    AnsiConsole.MarkupLine($"[green]✓[/] Lead {id} unarchived successfully");
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine($"[red]✗[/] Failed to unarchive lead: {Markup.Escape(response?.Error ?? "Unknown error")}");
+                }
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
+            }
+        }, idArgument);
+
+        return unarchiveCommand;
     }
 }

--- a/src/PipedriveCLI/Models/ApiModels.cs
+++ b/src/PipedriveCLI/Models/ApiModels.cs
@@ -163,6 +163,9 @@ public sealed class Lead
 
     [JsonPropertyName("cc_email")]
     public string? CcEmail { get; set; }
+
+    [JsonPropertyName("is_archived")]
+    public bool? IsArchived { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary
- Add `leads archive <id>` command to archive a lead
- Add `leads unarchive <id>` command to unarchive a lead
- Add `IsArchived` property to Lead model

Fixes #81

## Test plan
- [x] Run `pipedrive leads --help` - shows new archive/unarchive commands
- [x] All 107 unit tests pass