### PR TITLE
Add -y alias to force flags and show association type in activities list

### DIFF
--- a/src/PipedriveCLI.Tests/ActivitiesApiClientTests.cs
+++ b/src/PipedriveCLI.Tests/ActivitiesApiClientTests.cs
@@ -453,4 +453,116 @@ public class ActivitiesApiClientTests
         Assert.Equal("2024-11-01T10:00:00Z", response.Data.AddTime);
         Assert.Equal("2024-11-01T10:00:00Z", response.Data.UpdateTime);
     }
+
+    /// <summary>
+    /// Test that Activity deserialization handles lead_id field
+    /// </summary>
+    [Fact]
+    public void Activity_Deserialization_HandlesLeadId()
+    {
+        // Arrange - Activity with lead_id (leads use UUID strings, not integers)
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "id": 800,
+                "subject": "Lead Follow-up",
+                "type": "call",
+                "due_date": "2024-12-15",
+                "due_time": "11:00",
+                "done": false,
+                "deal_id": null,
+                "person_id": null,
+                "org_id": null,
+                "lead_id": "adf21080-0e10-11eb-879b-05d71fb426ec",
+                "note": "Follow up on new lead",
+                "add_time": "2024-12-01T00:00:00Z",
+                "update_time": "2024-12-01T00:00:00Z"
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseActivity);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Equal(800, response.Data.Id);
+        Assert.Equal("Lead Follow-up", response.Data.Subject);
+        Assert.Equal("adf21080-0e10-11eb-879b-05d71fb426ec", response.Data.LeadId);
+        Assert.Null(response.Data.DealId);
+        Assert.Null(response.Data.PersonId);
+        Assert.Null(response.Data.OrgId);
+    }
+
+    /// <summary>
+    /// Test activity serialization includes lead_id
+    /// </summary>
+    [Fact]
+    public void Activity_Serialization_IncludesLeadId()
+    {
+        // Arrange
+        var activity = new Activity
+        {
+            Subject = "Lead Call",
+            Type = "call",
+            DueDate = "2024-12-20",
+            LeadId = "test-lead-uuid-1234"
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(activity, ApiJsonContext.Default.Activity);
+        var deserialized = JsonSerializer.Deserialize(json, ApiJsonContext.Default.Activity);
+
+        // Assert
+        Assert.NotNull(deserialized);
+        Assert.Equal("Lead Call", deserialized.Subject);
+        Assert.Equal("test-lead-uuid-1234", deserialized.LeadId);
+        Assert.Contains("lead_id", json);
+    }
+
+    /// <summary>
+    /// Test that activities with all null associations are handled (orphaned activities)
+    /// </summary>
+    [Fact]
+    public void Activity_Deserialization_HandlesOrphanedActivity()
+    {
+        // Arrange - Activity with no associations (orphaned)
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "id": 900,
+                "subject": "Orphaned Activity",
+                "type": "task",
+                "due_date": "2024-12-20",
+                "due_time": null,
+                "done": false,
+                "deal_id": null,
+                "person_id": null,
+                "org_id": null,
+                "lead_id": null,
+                "note": "This activity has no associations",
+                "add_time": "2024-12-01T00:00:00Z",
+                "update_time": "2024-12-01T00:00:00Z"
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseActivity);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Equal(900, response.Data.Id);
+        Assert.Equal("Orphaned Activity", response.Data.Subject);
+        Assert.Null(response.Data.DealId);
+        Assert.Null(response.Data.PersonId);
+        Assert.Null(response.Data.OrgId);
+        Assert.Null(response.Data.LeadId);
+    }
 }

--- a/src/PipedriveCLI/Commands/ActivitiesCommands.cs
+++ b/src/PipedriveCLI/Commands/ActivitiesCommands.cs
@@ -163,7 +163,7 @@ public static class ActivitiesCommands
                             table.AddColumn("Type");
                             table.AddColumn("Due Date");
                             table.AddColumn("Done");
-                            table.AddColumn("Deal/Person/Org");
+                            table.AddColumn("Association");
                             table.AddColumn("Added");
 
                             foreach (var activity in response.Data)
@@ -172,10 +172,18 @@ public static class ActivitiesCommands
                                     ? $"{activity.DueDate} {activity.DueTime}"
                                     : activity.DueDate ?? "-";
 
-                                var entityInfo = activity.DealId?.ToString()
-                                    ?? activity.PersonId?.ToString()
-                                    ?? activity.OrgId?.ToString()
-                                    ?? "-";
+                                // Show association type with prefix for clarity
+                                string entityInfo;
+                                if (activity.DealId.HasValue)
+                                    entityInfo = $"Deal: {activity.DealId}";
+                                else if (!string.IsNullOrWhiteSpace(activity.LeadId))
+                                    entityInfo = $"Lead: {activity.LeadId}";
+                                else if (activity.PersonId.HasValue)
+                                    entityInfo = $"Person: {activity.PersonId}";
+                                else if (activity.OrgId.HasValue)
+                                    entityInfo = $"Org: {activity.OrgId}";
+                                else
+                                    entityInfo = "[dim](orphaned)[/]";
 
                                 var doneStatus = activity.Done ? "[green]✓[/]" : "[red]✗[/]";
 
@@ -542,7 +550,7 @@ public static class ActivitiesCommands
         deleteCommand.AddArgument(idArgument);
 
         var forceOption = new Option<bool>(
-            aliases: new[] { "--force", "-f" },
+            aliases: new[] { "--force", "-f", "-y" },
             description: "Skip confirmation prompt");
 
         deleteCommand.AddOption(forceOption);

--- a/src/PipedriveCLI/Commands/DealsCommands.cs
+++ b/src/PipedriveCLI/Commands/DealsCommands.cs
@@ -539,7 +539,7 @@ public static class DealsCommands
         deleteCommand.AddArgument(idArgument);
 
         var forceOption = new Option<bool>(
-            aliases: new[] { "--force", "-f" },
+            aliases: new[] { "--force", "-f", "-y" },
             description: "Skip confirmation prompt");
 
         deleteCommand.AddOption(forceOption);
@@ -600,7 +600,7 @@ public static class DealsCommands
         mergeCommand.AddArgument(mergeWithIdArgument);
 
         var forceOption = new Option<bool>(
-            aliases: new[] { "--force", "-f" },
+            aliases: new[] { "--force", "-f", "-y" },
             description: "Skip confirmation prompt");
 
         mergeCommand.AddOption(forceOption);

--- a/src/PipedriveCLI/Commands/LeadsCommands.cs
+++ b/src/PipedriveCLI/Commands/LeadsCommands.cs
@@ -405,7 +405,7 @@ public static class LeadsCommands
         deleteCommand.AddArgument(idArgument);
 
         var forceOption = new Option<bool>(
-            aliases: new[] { "--force", "-f" },
+            aliases: new[] { "--force", "-f", "-y" },
             description: "Skip confirmation prompt");
 
         deleteCommand.AddOption(forceOption);

--- a/src/PipedriveCLI/Commands/NotesCommands.cs
+++ b/src/PipedriveCLI/Commands/NotesCommands.cs
@@ -375,7 +375,7 @@ public static class NotesCommands
         deleteCommand.AddArgument(idArgument);
 
         var forceOption = new Option<bool>(
-            aliases: new[] { "--force", "-f" },
+            aliases: new[] { "--force", "-f", "-y" },
             description: "Skip confirmation prompt");
 
         deleteCommand.AddOption(forceOption);

--- a/src/PipedriveCLI/Commands/OrganizationsCommands.cs
+++ b/src/PipedriveCLI/Commands/OrganizationsCommands.cs
@@ -334,7 +334,7 @@ public static class OrganizationsCommands
         deleteCommand.AddArgument(idArgument);
 
         var forceOption = new Option<bool>(
-            aliases: new[] { "--force", "-f" },
+            aliases: new[] { "--force", "-f", "-y" },
             description: "Skip confirmation prompt");
 
         deleteCommand.AddOption(forceOption);
@@ -469,7 +469,7 @@ public static class OrganizationsCommands
         mergeCommand.AddArgument(mergeWithIdArgument);
 
         var forceOption = new Option<bool>(
-            aliases: new[] { "--force", "-f" },
+            aliases: new[] { "--force", "-f", "-y" },
             description: "Skip confirmation prompt");
 
         mergeCommand.AddOption(forceOption);

--- a/src/PipedriveCLI/Commands/PersonsCommands.cs
+++ b/src/PipedriveCLI/Commands/PersonsCommands.cs
@@ -398,7 +398,7 @@ public static class PersonsCommands
         deleteCommand.AddArgument(idArgument);
 
         var forceOption = new Option<bool>(
-            aliases: new[] { "--force", "-f" },
+            aliases: new[] { "--force", "-f", "-y" },
             description: "Skip confirmation prompt");
 
         deleteCommand.AddOption(forceOption);
@@ -541,7 +541,7 @@ public static class PersonsCommands
         mergeCommand.AddArgument(mergeWithIdArgument);
 
         var forceOption = new Option<bool>(
-            aliases: new[] { "--force", "-f" },
+            aliases: new[] { "--force", "-f", "-y" },
             description: "Skip confirmation prompt");
 
         mergeCommand.AddOption(forceOption);


### PR DESCRIPTION
## Summary
- **Issue #93**: Add `-y` as an alias for `--force`/`-f` on all delete and merge commands for a more intuitive UX (common Unix convention)
- **Issue #94**: Update `activities list` output to show association type with prefix (Deal:, Lead:, Person:, Org:) instead of just the ID, and display "(orphaned)" for activities without any association

## Changes
### Force flag alias (-y)
Added to:
- `activities delete`
- `deals delete` and `deals merge`
- `leads delete`
- `notes delete`
- `organizations delete` and `organizations merge`
- `persons delete` and `persons merge`

### Activities list association display
Changed the "Deal/Person/Org" column to "Association" with clearer type prefixes:
- `Deal: 123`
- `Lead: abc123-uuid`
- `Person: 456`
- `Org: 789`
- `(orphaned)` (dimmed) for activities with no associations

## Tests
Added 3 new unit tests:
- `Activity_Deserialization_HandlesLeadId` - Tests LeadId field deserialization
- `Activity_Serialization_IncludesLeadId` - Tests LeadId field serialization
- `Activity_Deserialization_HandlesOrphanedActivity` - Tests activities with all null associations

Closes #93
Closes #94