### PR TITLE
Improve API error handling and silence update check failures

### DIFF
--- a/src/PipedriveCLI/Models/ApiModels.cs
+++ b/src/PipedriveCLI/Models/ApiModels.cs
@@ -26,6 +26,21 @@ public sealed class PipedriveResponse<T>
 }
 
 /// <summary>
+/// Pipedrive API error response (non-generic for parsing errors without knowing the data type)
+/// </summary>
+public sealed class PipedriveErrorResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    [JsonPropertyName("error_info")]
+    public string? ErrorInfo { get; set; }
+}
+
+/// <summary>
 /// Additional metadata in API responses (pagination, etc.)
 /// </summary>
 public sealed class AdditionalData
@@ -1384,6 +1399,7 @@ public sealed class OrganizationField : BaseField
 [JsonSerializable(typeof(List<MailThread>))]
 [JsonSerializable(typeof(PipedriveResponse<MailThread>))]
 [JsonSerializable(typeof(PipedriveResponse<List<MailThread>>))]
+[JsonSerializable(typeof(PipedriveErrorResponse))]
 internal partial class ApiJsonContext : JsonSerializerContext
 {
 }

--- a/src/PipedriveCLI/Services/PipedriveApiClient.cs
+++ b/src/PipedriveCLI/Services/PipedriveApiClient.cs
@@ -1,8 +1,38 @@
+using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using PipedriveCLI.Models;
 
 namespace PipedriveCLI.Services;
+
+/// <summary>
+/// Exception thrown when the Pipedrive API returns an error response
+/// </summary>
+public class PipedriveApiException : Exception
+{
+    public HttpStatusCode StatusCode { get; }
+    public string? ApiError { get; }
+    public string? ApiErrorInfo { get; }
+
+    public PipedriveApiException(HttpStatusCode statusCode, string? apiError, string? apiErrorInfo)
+        : base(FormatMessage(statusCode, apiError, apiErrorInfo))
+    {
+        StatusCode = statusCode;
+        ApiError = apiError;
+        ApiErrorInfo = apiErrorInfo;
+    }
+
+    private static string FormatMessage(HttpStatusCode statusCode, string? apiError, string? apiErrorInfo)
+    {
+        if (!string.IsNullOrWhiteSpace(apiError))
+        {
+            return !string.IsNullOrWhiteSpace(apiErrorInfo)
+                ? $"{apiError} - {apiErrorInfo}"
+                : apiError;
+        }
+        return $"HTTP {(int)statusCode} ({statusCode})";
+    }
+}
 
 /// <summary>
 /// HTTP client for interacting with the Pipedrive API
@@ -42,6 +72,40 @@ public sealed class PipedriveApiClient : IDisposable
     }
 
     /// <summary>
+    /// Ensures the response is successful, or throws a PipedriveApiException with the actual error message
+    /// </summary>
+    private static async Task EnsureSuccessOrThrowApiErrorAsync(HttpResponseMessage response)
+    {
+        if (response.IsSuccessStatusCode)
+            return;
+
+        // Try to read the response body to get the actual error message
+        string? apiError = null;
+        string? apiErrorInfo = null;
+
+        try
+        {
+            var responseBody = await response.Content.ReadAsStringAsync();
+            if (!string.IsNullOrWhiteSpace(responseBody))
+            {
+                // Try to parse as a Pipedrive error response
+                var errorResponse = JsonSerializer.Deserialize(responseBody, ApiJsonContext.Default.PipedriveErrorResponse);
+                if (errorResponse != null)
+                {
+                    apiError = errorResponse.Error;
+                    apiErrorInfo = errorResponse.ErrorInfo;
+                }
+            }
+        }
+        catch
+        {
+            // Ignore JSON parsing errors - we'll fall back to generic message
+        }
+
+        throw new PipedriveApiException(response.StatusCode, apiError, apiErrorInfo);
+    }
+
+    /// <summary>
     /// Makes a GET request to the Pipedrive API and returns raw JSON string
     /// </summary>
     public async Task<string> GetAsync(string endpoint, Dictionary<string, string>? queryParams = null)
@@ -51,7 +115,7 @@ public sealed class PipedriveApiClient : IDisposable
         var url = await BuildUrlWithApiKeyAsync(endpoint, queryParams);
         var response = await _httpClient.GetAsync(url);
 
-        response.EnsureSuccessStatusCode();
+        await EnsureSuccessOrThrowApiErrorAsync(response);
 
         return await response.Content.ReadAsStringAsync();
     }
@@ -67,7 +131,7 @@ public sealed class PipedriveApiClient : IDisposable
         var content = new StringContent(jsonData, System.Text.Encoding.UTF8, "application/json");
         var response = await _httpClient.PostAsync(url, content);
 
-        response.EnsureSuccessStatusCode();
+        await EnsureSuccessOrThrowApiErrorAsync(response);
 
         return await response.Content.ReadAsStringAsync();
     }
@@ -83,7 +147,7 @@ public sealed class PipedriveApiClient : IDisposable
         var content = new StringContent(jsonData, System.Text.Encoding.UTF8, "application/json");
         var response = await _httpClient.PutAsync(url, content);
 
-        response.EnsureSuccessStatusCode();
+        await EnsureSuccessOrThrowApiErrorAsync(response);
 
         return await response.Content.ReadAsStringAsync();
     }
@@ -103,7 +167,7 @@ public sealed class PipedriveApiClient : IDisposable
         };
         var response = await _httpClient.SendAsync(request);
 
-        response.EnsureSuccessStatusCode();
+        await EnsureSuccessOrThrowApiErrorAsync(response);
 
         return await response.Content.ReadAsStringAsync();
     }
@@ -201,7 +265,7 @@ public sealed class PipedriveApiClient : IDisposable
 
         // Use absolute URI to avoid modifying BaseAddress
         var response = await _httpClient.GetAsync(new Uri(absoluteUrl, UriKind.Absolute));
-        response.EnsureSuccessStatusCode();
+        await EnsureSuccessOrThrowApiErrorAsync(response);
 
         var jsonResponse = await response.Content.ReadAsStringAsync();
 

--- a/src/PipedriveCLI/Services/UpdateService.cs
+++ b/src/PipedriveCLI/Services/UpdateService.cs
@@ -81,10 +81,9 @@ public sealed class UpdateService : IUpdateService
                 }
             }
         }
-        catch (Exception ex)
+        catch
         {
-            // Log but don't fail
-            Console.Error.WriteLine($"Update check failed: {ex.Message}");
+            // Silently ignore update check failures - don't interrupt user workflow
         }
 
         return null;


### PR DESCRIPTION
## Summary
- Add `PipedriveApiException` for parsing actual API error messages from Pipedrive API responses
- Replace generic `EnsureSuccessStatusCode()` with custom error parser that extracts `error` and `error_info` fields from API responses
- Add `PipedriveErrorResponse` model for deserializing error payloads
- Make update check failures silent to avoid interrupting user workflow

## Test plan
- [x] Build succeeds
- [x] All 128 tests pass
- [ ] Manual test: API calls with invalid credentials should show actual error message (e.g., "Access denied" instead of generic "403 Forbidden")
- [ ] Manual test: Update check failures should not print error messages to stderr

Fixes #99, #101