### PR TITLE
Add --lead-id filter option for notes list command

### DIFF
--- a/src/PipedriveCLI/Commands/NotesCommands.cs
+++ b/src/PipedriveCLI/Commands/NotesCommands.cs
@@ -54,11 +54,16 @@ public static class NotesCommands
             aliases: new[] { "--org-id", "-o" },
             description: "Filter notes by organization ID");
 
+        var leadIdOption = new Option<string?>(
+            aliases: new[] { "--lead-id" },
+            description: "Filter notes by lead ID (UUID)");
+
         listCommand.AddOption(limitOption);
         listCommand.AddOption(startOption);
         listCommand.AddOption(dealIdOption);
         listCommand.AddOption(personIdOption);
         listCommand.AddOption(orgIdOption);
+        listCommand.AddOption(leadIdOption);
 
         listCommand.SetHandler(async (context) =>
         {
@@ -67,6 +72,7 @@ public static class NotesCommands
             var dealId = context.ParseResult.GetValueForOption(dealIdOption);
             var personId = context.ParseResult.GetValueForOption(personIdOption);
             var orgId = context.ParseResult.GetValueForOption(orgIdOption);
+            var leadId = context.ParseResult.GetValueForOption(leadIdOption);
 
             try
             {
@@ -78,7 +84,7 @@ public static class NotesCommands
                         ctx.Spinner(Spinner.Known.Dots);
                         ctx.SpinnerStyle(Style.Parse("green"));
 
-                        var response = await apiClient.GetNotesAsync(limit, start, dealId, personId, orgId);
+                        var response = await apiClient.GetNotesAsync(limit, start, dealId, personId, orgId, leadId);
 
                         if (response?.Success == true)
                         {

--- a/src/PipedriveCLI/Services/PipedriveApiClient.cs
+++ b/src/PipedriveCLI/Services/PipedriveApiClient.cs
@@ -526,7 +526,7 @@ public sealed class PipedriveApiClient : IDisposable
     /// <summary>
     /// Retrieves all notes with pagination support
     /// </summary>
-    public async Task<PipedriveResponse<List<Note>>?> GetNotesAsync(int? limit = null, int? start = null, int? dealId = null, int? personId = null, int? orgId = null)
+    public async Task<PipedriveResponse<List<Note>>?> GetNotesAsync(int? limit = null, int? start = null, int? dealId = null, int? personId = null, int? orgId = null, string? leadId = null)
     {
         var queryParams = new Dictionary<string, string>();
         if (limit.HasValue) queryParams["limit"] = limit.Value.ToString();
@@ -534,6 +534,7 @@ public sealed class PipedriveApiClient : IDisposable
         if (dealId.HasValue) queryParams["deal_id"] = dealId.Value.ToString();
         if (personId.HasValue) queryParams["person_id"] = personId.Value.ToString();
         if (orgId.HasValue) queryParams["org_id"] = orgId.Value.ToString();
+        if (!string.IsNullOrWhiteSpace(leadId)) queryParams["lead_id"] = leadId;
 
         var jsonResponse = await GetAsync("notes", queryParams);
         return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseListNote);


### PR DESCRIPTION
## Summary
- Add `--lead-id` option to `notes list` command for filtering notes by lead ID
- Update `GetNotesAsync` API method to accept `leadId` parameter
- Consistent with existing `--deal-id`, `--person-id`, and `--org-id` filters

## Example usage
```bash
pipedrive notes list --lead-id "34222760-ba57-11f0-945c-134e56493ed5"
```

## Test plan
- [x] Build succeeds
- [x] All 128 tests pass
- [x] `--lead-id` option appears in `notes list --help`
- [ ] Manual test: filter notes by lead ID

Fixes #98