### PR TITLE
Add --yes/-y flag for non-interactive update command

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,34 +7,16 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.7.0</VersionPrefix>
-    <PackageReleaseNotes>This release focuses on stability improvements, fixing critical display issues and improving error handling across the CLI.
-
-**Bug Fixes**
-
-- **Fixed ID Corruption in Table Rendering** ([#102](https://github.com/Aaronontheweb/pipedrive-cli/issues/102), [#103](https://github.com/Aaronontheweb/pipedrive-cli/issues/103))
-  - Added NoWrap() to ID columns across all list commands
-  - Prevents IDs from wrapping across multiple lines in narrow terminal windows
-  - Ensures copy-paste reliability for automation and scripting
-
-- **Improved API Error Handling** ([#101](https://github.com/Aaronontheweb/pipedrive-cli/issues/101), [#104](https://github.com/Aaronontheweb/pipedrive-cli/issues/104))
-  - Now displays actual Pipedrive API error messages instead of generic HTTP errors
-  - Helps users understand and resolve API issues faster
-  - Better troubleshooting for validation errors and permission issues
-
-- **Silenced Update Check Failures** ([#99](https://github.com/Aaronontheweb/pipedrive-cli/issues/99), [#104](https://github.com/Aaronontheweb/pipedrive-cli/issues/104))
-  - Update availability checks no longer interrupt user workflow with error messages
-  - Graceful degradation when GitHub API is unreachable
-  - Maintains responsive CLI experience even when offline
+    <VersionPrefix>0.7.1</VersionPrefix>
+    <PackageReleaseNotes>Added `--yes`/`-y` flag for non-interactive update command.
 
 **New Features**
 
-- **Lead ID Filter for Notes** ([#98](https://github.com/Aaronontheweb/pipedrive-cli/issues/98), [#105](https://github.com/Aaronontheweb/pipedrive-cli/issues/105))
-  - Added `--lead-id` option to `notes list` command
-  - Filter notes by associated lead UUID
-  - Example: `pipedrive notes list --lead-id "e126ec80-cfff-11f0-8c59-fd43bfd483d9"`
-
----</PackageReleaseNotes>
+- **Non-Interactive Update Flag** ([#107](https://github.com/Aaronontheweb/pipedrive-cli/issues/107))
+  - Added `--yes`/`-y` aliases to `pipedrive update` command
+  - Enables updates in non-interactive environments (scripts, CI/CD, LLM agents)
+  - Example: `pipedrive update --yes` or `pipedrive update -y`
+</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Visual Studio C# settings -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,16 @@
+#### 0.7.1 December 4 2025 ####
+
+Added `--yes`/`-y` flag for non-interactive update command.
+
+**New Features**
+
+- **Non-Interactive Update Flag** ([#107](https://github.com/Aaronontheweb/pipedrive-cli/issues/107))
+  - Added `--yes`/`-y` aliases to `pipedrive update` command
+  - Enables updates in non-interactive environments (scripts, CI/CD, LLM agents)
+  - Example: `pipedrive update --yes` or `pipedrive update -y`
+
+---
+
 #### 0.7.0 December 4 2025 ####
 
 This release focuses on stability improvements, fixing critical display issues and improving error handling across the CLI.

--- a/src/PipedriveCLI/Commands/UpdateCommands.cs
+++ b/src/PipedriveCLI/Commands/UpdateCommands.cs
@@ -17,7 +17,7 @@ public static class UpdateCommands
         );
 
         var forceOption = new Option<bool>(
-            new[] { "--force", "-f" },
+            new[] { "--force", "-f", "--yes", "-y" },
             "Skip confirmation prompt"
         );
 


### PR DESCRIPTION
## Summary
- Add `--yes` and `-y` aliases to the update command's force option
- Enables updates in non-interactive environments (scripts, CI/CD, LLM agents)
- Updates version to 0.7.1 and release notes

## Example usage
```bash
pipedrive update --yes
pipedrive update -y
```

## Test plan
- [x] Build succeeds
- [x] All 128 tests pass
- [x] `--yes` and `-y` flags appear in `update --help`

Fixes #107