### PR TITLE
Revert redundant --yes/-y aliases from update command

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,15 +7,8 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.7.1</VersionPrefix>
-    <PackageReleaseNotes>Added `--yes`/`-y` flag for non-interactive update command.
-
-**New Features**
-
-- **Non-Interactive Update Flag** ([#107](https://github.com/Aaronontheweb/pipedrive-cli/issues/107))
-  - Added `--yes`/`-y` aliases to `pipedrive update` command
-  - Enables updates in non-interactive environments (scripts, CI/CD, LLM agents)
-  - Example: `pipedrive update --yes` or `pipedrive update -y`
+    <VersionPrefix>0.7.2</VersionPrefix>
+    <PackageReleaseNotes>Reverted redundant --yes/-y aliases from update command (--force/-f already existed).
 </PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,13 +1,6 @@
-#### 0.7.1 December 4 2025 ####
+#### 0.7.2 December 5 2025 ####
 
-Added `--yes`/`-y` flag for non-interactive update command.
-
-**New Features**
-
-- **Non-Interactive Update Flag** ([#107](https://github.com/Aaronontheweb/pipedrive-cli/issues/107))
-  - Added `--yes`/`-y` aliases to `pipedrive update` command
-  - Enables updates in non-interactive environments (scripts, CI/CD, LLM agents)
-  - Example: `pipedrive update --yes` or `pipedrive update -y`
+Reverted redundant `--yes`/`-y` aliases from update command - the existing `--force`/`-f` flag already provides this functionality.
 
 ---
 

--- a/src/PipedriveCLI/Commands/UpdateCommands.cs
+++ b/src/PipedriveCLI/Commands/UpdateCommands.cs
@@ -17,7 +17,7 @@ public static class UpdateCommands
         );
 
         var forceOption = new Option<bool>(
-            new[] { "--force", "-f", "--yes", "-y" },
+            new[] { "--force", "-f" },
             "Skip confirmation prompt"
         );
 


### PR DESCRIPTION
## Summary
Reverts the `--yes`/`-y` aliases added in 0.7.1 - the existing `--force`/`-f` flag already provided this functionality.

Users can use `pipedrive update --force` or `pipedrive update -f` to skip confirmation prompts.

Closes #107