### PR TITLE
Add person and deal filters to emails threads command

### DIFF
--- a/src/PipedriveCLI/Commands/EmailsCommands.cs
+++ b/src/PipedriveCLI/Commands/EmailsCommands.cs
@@ -216,19 +216,41 @@ public static class EmailsCommands
             aliases: ["--start", "-s"],
             description: "Pagination start (default: 0)");
 
+        var personIdOption = new Option<int?>(
+            aliases: ["--person-id", "-p"],
+            description: "Filter threads involving a specific person");
+
+        var dealIdOption = new Option<int?>(
+            aliases: ["--deal-id", "-d"],
+            description: "Filter threads linked to a specific deal");
+
         threadsCommand.AddOption(folderOption);
         threadsCommand.AddOption(limitOption);
         threadsCommand.AddOption(startOption);
+        threadsCommand.AddOption(personIdOption);
+        threadsCommand.AddOption(dealIdOption);
 
-        threadsCommand.SetHandler(async (folder, limit, start) =>
+        threadsCommand.SetHandler(async context =>
         {
+            var folder = context.ParseResult.GetValueForOption(folderOption);
+            var limit = context.ParseResult.GetValueForOption(limitOption);
+            var start = context.ParseResult.GetValueForOption(startOption);
+            var personId = context.ParseResult.GetValueForOption(personIdOption);
+            var dealId = context.ParseResult.GetValueForOption(dealIdOption);
+
             try
             {
                 await apiClient.InitializeAsync();
 
-                var statusText = string.IsNullOrWhiteSpace(folder)
-                    ? "Fetching mail threads..."
-                    : $"Fetching {folder} mail threads...";
+                // Build status text based on filters
+                var statusParts = new List<string>();
+                if (!string.IsNullOrWhiteSpace(folder)) statusParts.Add(folder);
+                if (personId.HasValue) statusParts.Add($"person {personId}");
+                if (dealId.HasValue) statusParts.Add($"deal {dealId}");
+
+                var statusText = statusParts.Count > 0
+                    ? $"Fetching mail threads for {string.Join(", ", statusParts)}..."
+                    : "Fetching mail threads...";
 
                 await AnsiConsole.Status()
                     .StartAsync(statusText, async ctx =>
@@ -236,7 +258,7 @@ public static class EmailsCommands
                         ctx.Spinner(Spinner.Known.Dots);
                         ctx.SpinnerStyle(Style.Parse("green"));
 
-                        var response = await apiClient.GetMailThreadsAsync(folder, limit ?? 50, start);
+                        var response = await apiClient.GetMailThreadsAsync(folder, limit ?? 50, start, personId, dealId);
 
                         if (response?.Success == true && response.Data != null)
                         {
@@ -253,7 +275,7 @@ public static class EmailsCommands
             {
                 AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
             }
-        }, folderOption, limitOption, startOption);
+        });
 
         return threadsCommand;
     }

--- a/src/PipedriveCLI/Services/PipedriveApiClient.cs
+++ b/src/PipedriveCLI/Services/PipedriveApiClient.cs
@@ -932,17 +932,21 @@ public sealed class PipedriveApiClient : IDisposable
     #region Mail Threads Operations
 
     /// <summary>
-    /// Gets mail threads with optional folder filter
+    /// Gets mail threads with optional filters
     /// </summary>
     /// <param name="folder">Filter by folder: inbox, drafts, sent, archive</param>
     /// <param name="limit">Number of threads to return</param>
     /// <param name="start">Pagination start</param>
-    public async Task<PipedriveResponse<List<MailThread>>?> GetMailThreadsAsync(string? folder = null, int? limit = null, int? start = null)
+    /// <param name="personId">Filter by person ID</param>
+    /// <param name="dealId">Filter by deal ID</param>
+    public async Task<PipedriveResponse<List<MailThread>>?> GetMailThreadsAsync(string? folder = null, int? limit = null, int? start = null, int? personId = null, int? dealId = null)
     {
         var queryParams = new Dictionary<string, string>();
         if (!string.IsNullOrWhiteSpace(folder)) queryParams["folder"] = folder;
         if (limit.HasValue) queryParams["limit"] = limit.Value.ToString();
         if (start.HasValue) queryParams["start"] = start.Value.ToString();
+        if (personId.HasValue) queryParams["person_id"] = personId.Value.ToString();
+        if (dealId.HasValue) queryParams["deal_id"] = dealId.Value.ToString();
 
         var jsonResponse = await GetAsync("mailbox/mailThreads", queryParams);
         return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseListMailThread);


### PR DESCRIPTION
## Summary

This PR implements issue #110 by adding person and deal filtering to the `emails threads` command, making it easier to review communication history before customer outreach.

### New Options

- `--person-id` / `-p`: Filter email threads involving a specific person
- `--deal-id` / `-d`: Filter email threads linked to a specific deal

### Implementation Details

- Updated `GetMailThreadsAsync` in PipedriveApiClient to accept optional `personId` and `dealId` parameters
- Added corresponding query parameters (`person_id`, `deal_id`) to the Pipedrive API call
- Enhanced status messaging to dynamically reflect active filters
- Filters can be combined with existing options (folder, limit, start)

### Usage Examples

```bash
# View all email threads with a specific person
pipedrive emails threads --person-id 12702

# View sent emails for a specific deal
pipedrive emails threads --folder sent --deal-id 456

# Combine person and folder filters
pipedrive emails threads --person-id 123 --folder inbox

# View all threads for a deal with pagination
pipedrive emails threads --deal-id 789 --limit 20
```

### Use Case

Before reaching out to a customer, users can now quickly review prior communication:
```bash
pipedrive emails threads --person-id 12702 --folder sent
```

This displays all sent email threads with that contact, helping avoid duplicate outreach and providing context for follow-ups.

Closes #110