### PR TITLE
Fix deals list --org-id filter returning no results

### DIFF
--- a/src/PipedriveCLI/Services/PipedriveApiClient.cs
+++ b/src/PipedriveCLI/Services/PipedriveApiClient.cs
@@ -323,7 +323,15 @@ public sealed class PipedriveApiClient : IDisposable
         var queryParams = new Dictionary<string, string>();
         if (limit.HasValue) queryParams["limit"] = limit.Value.ToString();
         if (start.HasValue) queryParams["start"] = start.Value.ToString();
-        if (!string.IsNullOrWhiteSpace(status)) queryParams["status"] = status;
+
+        // The /organizations/{id}/deals endpoint uses "all_not_deleted" instead of "all"
+        // Map "all" to "all_not_deleted" for consistency with the main deals endpoint
+        if (!string.IsNullOrWhiteSpace(status))
+        {
+            queryParams["status"] = status.Equals("all", StringComparison.OrdinalIgnoreCase)
+                ? "all_not_deleted"
+                : status;
+        }
 
         var jsonResponse = await GetAsync($"organizations/{orgId}/deals", queryParams);
         return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseListDeal);


### PR DESCRIPTION
## Summary
- The `/organizations/{id}/deals` endpoint doesn't support `status=all` like the regular `/deals` endpoint
- This caused `pipedrive deals list --org-id <id> --status all` to return 0 results even when deals existed
- Fixed by mapping "all" to "all_not_deleted" in `GetOrganizationDealsAsync`

## Test plan
- [x] Verified `pipedrive deals list --org-id 387 --status all` now returns 5 deals (was returning 0)
- [x] All 128 existing unit tests pass

Fixes #125