### PR TITLE
Add support for clearing date fields on deals

### DIFF
--- a/src/PipedriveCLI.Tests/DealsApiClientTests.cs
+++ b/src/PipedriveCLI.Tests/DealsApiClientTests.cs
@@ -552,4 +552,51 @@ public class DealsApiClientTests
         Assert.NotNull(response.Data);
         Assert.Null(response.Data.CcEmail);
     }
+
+    /// <summary>
+    /// Test that Deal update with clear fields generates correct JSON with explicit nulls
+    /// </summary>
+    [Fact]
+    public void Deal_UpdateWithClearFields_GeneratesCorrectJson()
+    {
+        // Arrange - A deal with some fields set
+        var deal = new Deal
+        {
+            Title = "Updated Title"
+        };
+
+        var clearFields = new List<string> { "expected_close_date" };
+
+        // Act - Simulate what the API client does to build JSON with clear fields
+        var dealJson = JsonSerializer.Serialize(deal, ApiJsonContext.Default.Deal);
+        using var dealDoc = JsonDocument.Parse(dealJson);
+
+        using var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream);
+
+        writer.WriteStartObject();
+        foreach (var property in dealDoc.RootElement.EnumerateObject())
+        {
+            property.WriteTo(writer);
+        }
+        foreach (var field in clearFields)
+        {
+            if (!dealDoc.RootElement.TryGetProperty(field, out _))
+            {
+                writer.WriteNull(field);
+            }
+        }
+        writer.WriteEndObject();
+        writer.Flush();
+
+        var resultJson = System.Text.Encoding.UTF8.GetString(stream.ToArray());
+        using var resultDoc = JsonDocument.Parse(resultJson);
+
+        // Assert - The JSON should contain the title and an explicit null for expected_close_date
+        Assert.True(resultDoc.RootElement.TryGetProperty("title", out var titleProp));
+        Assert.Equal("Updated Title", titleProp.GetString());
+
+        Assert.True(resultDoc.RootElement.TryGetProperty("expected_close_date", out var dateProp));
+        Assert.Equal(JsonValueKind.Null, dateProp.ValueKind);
+    }
 }

--- a/src/PipedriveCLI/Commands/DealsCommands.cs
+++ b/src/PipedriveCLI/Commands/DealsCommands.cs
@@ -399,7 +399,7 @@ public static class DealsCommands
 
         var expectedCloseDateOption = new Option<string?>(
             aliases: new[] { "--expected-close-date", "-d" },
-            description: "New expected close date (YYYY-MM-DD)");
+            description: "New expected close date (YYYY-MM-DD), or 'clear' to remove the date");
 
         var customFieldsOption = new Option<string?>(
             aliases: new[] { "--custom-fields", "-cf" },
@@ -456,9 +456,12 @@ public static class DealsCommands
 
             try
             {
+                // Check if user wants to clear the date field
+                var clearExpectedCloseDate = IsClearValue(expectedCloseDate);
+
                 if (string.IsNullOrWhiteSpace(title) && !value.HasValue &&
                     string.IsNullOrWhiteSpace(currency) && !stageId.HasValue &&
-                    string.IsNullOrWhiteSpace(status) && string.IsNullOrWhiteSpace(expectedCloseDate) &&
+                    string.IsNullOrWhiteSpace(status) && !clearExpectedCloseDate && string.IsNullOrWhiteSpace(expectedCloseDate) &&
                     string.IsNullOrWhiteSpace(customFields) && string.IsNullOrWhiteSpace(wonTime) &&
                     string.IsNullOrWhiteSpace(lostTime) && !personId.HasValue &&
                     !orgId.HasValue && !probability.HasValue)
@@ -483,13 +486,17 @@ public static class DealsCommands
                 await apiClient.InitializeAsync();
 
                 var deal = new Deal();
+                var fieldsToClears = new List<string>();
 
                 if (!string.IsNullOrWhiteSpace(title)) deal.Title = title;
                 if (value.HasValue) deal.Value = value.Value;
                 if (!string.IsNullOrWhiteSpace(currency)) deal.Currency = currency;
                 if (stageId.HasValue) deal.StageId = stageId;
                 if (!string.IsNullOrWhiteSpace(status)) deal.Status = status;
-                if (!string.IsNullOrWhiteSpace(expectedCloseDate)) deal.ExpectedCloseDate = expectedCloseDate;
+                if (clearExpectedCloseDate)
+                    fieldsToClears.Add("expected_close_date");
+                else if (!string.IsNullOrWhiteSpace(expectedCloseDate))
+                    deal.ExpectedCloseDate = expectedCloseDate;
                 if (!string.IsNullOrWhiteSpace(wonTime)) deal.WonTime = NormalizeDateTimeFormat(wonTime);
                 if (!string.IsNullOrWhiteSpace(lostTime)) deal.LostTime = NormalizeDateTimeFormat(lostTime);
                 if (personId.HasValue) deal.PersonId = personId;
@@ -507,7 +514,9 @@ public static class DealsCommands
                     {
                         ctx.Spinner(Spinner.Known.Dots);
                         ctx.SpinnerStyle(Style.Parse("green"));
-                        return await apiClient.UpdateDealAsync(id, deal);
+                        return fieldsToClears.Count > 0
+                            ? await apiClient.UpdateDealAsync(id, deal, fieldsToClears)
+                            : await apiClient.UpdateDealAsync(id, deal);
                     });
 
                 if (response?.Success == true)
@@ -662,6 +671,19 @@ public static class DealsCommands
             return $"{input} 12:00:00";
         }
         return input;
+    }
+
+    /// <summary>
+    /// Checks if a string value indicates the user wants to clear/null the field.
+    /// Accepts "clear", "null", or empty string.
+    /// </summary>
+    private static bool IsClearValue(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return false;
+
+        return value.Equals("clear", StringComparison.OrdinalIgnoreCase) ||
+               value.Equals("null", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/PipedriveCLI/Services/PipedriveApiClient.cs
+++ b/src/PipedriveCLI/Services/PipedriveApiClient.cs
@@ -367,6 +367,46 @@ public sealed class PipedriveApiClient : IDisposable
     }
 
     /// <summary>
+    /// Updates an existing deal with support for clearing fields by setting them to null.
+    /// Use this overload when you need to clear date fields or other nullable fields.
+    /// </summary>
+    /// <param name="id">The deal ID</param>
+    /// <param name="deal">The deal object with fields to update</param>
+    /// <param name="clearFields">List of field names to explicitly set to null (e.g., "expected_close_date")</param>
+    public async Task<PipedriveResponse<Deal>?> UpdateDealAsync(int id, Deal deal, IEnumerable<string> clearFields)
+    {
+        // Build JSON manually to include explicit nulls for cleared fields
+        using var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream);
+
+        writer.WriteStartObject();
+
+        // First, serialize the non-null deal properties
+        var dealJson = JsonSerializer.Serialize(deal, ApiJsonContext.Default.Deal);
+        using var dealDoc = JsonDocument.Parse(dealJson);
+        foreach (var property in dealDoc.RootElement.EnumerateObject())
+        {
+            property.WriteTo(writer);
+        }
+
+        // Then, add explicit nulls for fields to clear (if not already in deal)
+        foreach (var field in clearFields)
+        {
+            if (!dealDoc.RootElement.TryGetProperty(field, out _))
+            {
+                writer.WriteNull(field);
+            }
+        }
+
+        writer.WriteEndObject();
+        writer.Flush();
+
+        var jsonData = System.Text.Encoding.UTF8.GetString(stream.ToArray());
+        var jsonResponse = await PutAsync($"deals/{id}", jsonData);
+        return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseDeal);
+    }
+
+    /// <summary>
     /// Deletes a deal
     /// </summary>
     public async Task<bool> DeleteDealAsync(int id)


### PR DESCRIPTION
## Summary
- The Pipedrive API requires explicit null values to clear date fields
- The JSON serializer uses `WhenWritingDefault` which skips null values
- Added new `UpdateDealAsync` overload that builds JSON with explicit nulls for fields to clear
- Users can now use `--expected-close-date clear` or `--expected-close-date null` to remove the date

## Test plan
- [x] Manually tested: set date on deal 1614, then cleared it with `--expected-close-date clear`
- [x] Added unit test for JSON generation with explicit nulls
- [x] All 129 unit tests pass

## Usage
```bash
# Set a date
pipedrive deals update 1614 --expected-close-date 2026-05-01

# Clear the date
pipedrive deals update 1614 --expected-close-date clear
```

Fixes #128