### PR TITLE
Add --lost-reason flag to deals update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,9 @@ pipedrive deals create --title "Q4 License" --value 25000 [--currency USD] [--pe
 # Update an existing deal
 pipedrive deals update <id> --title "Updated Deal" [--value 30000] [--status won]
 
+# Mark deal as lost with a reason
+pipedrive deals update <id> --status lost --lost-reason "Customer chose competitor"
+
 # Update deal with custom fields (use hash keys from --raw-keys)
 pipedrive deals update <id> --custom-fields "hash1=value1,hash2=value2"
 

--- a/src/PipedriveCLI.Tests/DealsApiClientTests.cs
+++ b/src/PipedriveCLI.Tests/DealsApiClientTests.cs
@@ -758,6 +758,108 @@ public class DealsApiClientTests
     }
 
     /// <summary>
+    /// Test that Deal deserialization handles lost deal with lost_reason
+    /// </summary>
+    [Fact]
+    public void Deal_Deserialization_LostDealWithLostReason()
+    {
+        // Arrange - A lost deal with lost_time and lost_reason
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "id": 700,
+                "title": "Lost Deal",
+                "value": 25000.00,
+                "currency": "USD",
+                "person_id": 111,
+                "org_id": 222,
+                "status": "lost",
+                "probability": 0,
+                "lost_time": "2024-06-15T14:30:00Z",
+                "lost_reason": "Customer decommissioned their Akka.NET application",
+                "add_time": "2024-01-01T00:00:00Z",
+                "update_time": "2024-06-15T14:30:00Z"
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseDeal);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Equal("lost", response.Data.Status);
+        Assert.Equal(0m, response.Data.Probability);
+        Assert.Equal("2024-06-15T14:30:00Z", response.Data.LostTime);
+        Assert.Equal("Customer decommissioned their Akka.NET application", response.Data.LostReason);
+        Assert.Null(response.Data.WonTime);
+    }
+
+    /// <summary>
+    /// Test that Deal serialization includes lost_reason for update operations
+    /// </summary>
+    [Fact]
+    public void Deal_Serialization_WithLostReason()
+    {
+        // Arrange - A deal being marked as lost with a reason
+        var deal = new Deal
+        {
+            Status = "lost",
+            LostTime = "2024-06-15 14:30:00",
+            LostReason = "Budget constraints"
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(deal, ApiJsonContext.Default.Deal);
+        var deserialized = JsonSerializer.Deserialize(json, ApiJsonContext.Default.Deal);
+
+        // Assert
+        Assert.NotNull(deserialized);
+        Assert.Equal("lost", deserialized.Status);
+        Assert.Equal("2024-06-15 14:30:00", deserialized.LostTime);
+        Assert.Equal("Budget constraints", deserialized.LostReason);
+    }
+
+    /// <summary>
+    /// Test that Deal deserialization handles null/missing lost_reason
+    /// </summary>
+    [Fact]
+    public void Deal_Deserialization_LostDealWithoutLostReason()
+    {
+        // Arrange - A lost deal without lost_reason (can happen for older deals)
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "id": 701,
+                "title": "Lost Deal Without Reason",
+                "value": 15000.00,
+                "currency": "USD",
+                "status": "lost",
+                "lost_time": "2024-05-01T10:00:00Z",
+                "lost_reason": null,
+                "add_time": "2024-01-01T00:00:00Z",
+                "update_time": "2024-05-01T10:00:00Z"
+            }
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseDeal);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Equal("lost", response.Data.Status);
+        Assert.Equal("2024-05-01T10:00:00Z", response.Data.LostTime);
+        Assert.Null(response.Data.LostReason);
+    }
+
+    /// <summary>
     /// Test DealProduct list with empty data
     /// </summary>
     [Fact]

--- a/src/PipedriveCLI/Commands/DealsCommands.cs
+++ b/src/PipedriveCLI/Commands/DealsCommands.cs
@@ -417,6 +417,10 @@ public static class DealsCommands
             aliases: new[] { "--lost-time" },
             description: "Date/time when the deal was lost (YYYY-MM-DD or YYYY-MM-DD HH:mm:ss). Use with --status lost or on already lost deals.");
 
+        var lostReasonOption = new Option<string?>(
+            aliases: new[] { "--lost-reason" },
+            description: "Reason why the deal was lost. Use with --status lost or on already lost deals.");
+
         var personIdOption = new Option<int?>(
             aliases: new[] { "--person-id", "-p" },
             description: "Change associated person ID");
@@ -438,6 +442,7 @@ public static class DealsCommands
         updateCommand.AddOption(customFieldsOption);
         updateCommand.AddOption(wonTimeOption);
         updateCommand.AddOption(lostTimeOption);
+        updateCommand.AddOption(lostReasonOption);
         updateCommand.AddOption(personIdOption);
         updateCommand.AddOption(orgIdOption);
         updateCommand.AddOption(probabilityOption);
@@ -454,6 +459,7 @@ public static class DealsCommands
             var customFields = context.ParseResult.GetValueForOption(customFieldsOption);
             var wonTime = context.ParseResult.GetValueForOption(wonTimeOption);
             var lostTime = context.ParseResult.GetValueForOption(lostTimeOption);
+            var lostReason = context.ParseResult.GetValueForOption(lostReasonOption);
             var personId = context.ParseResult.GetValueForOption(personIdOption);
             var orgId = context.ParseResult.GetValueForOption(orgIdOption);
             var probability = context.ParseResult.GetValueForOption(probabilityOption);
@@ -467,8 +473,8 @@ public static class DealsCommands
                     string.IsNullOrWhiteSpace(currency) && !stageId.HasValue &&
                     string.IsNullOrWhiteSpace(status) && !clearExpectedCloseDate && string.IsNullOrWhiteSpace(expectedCloseDate) &&
                     string.IsNullOrWhiteSpace(customFields) && string.IsNullOrWhiteSpace(wonTime) &&
-                    string.IsNullOrWhiteSpace(lostTime) && !personId.HasValue &&
-                    !orgId.HasValue && !probability.HasValue)
+                    string.IsNullOrWhiteSpace(lostTime) && string.IsNullOrWhiteSpace(lostReason) &&
+                    !personId.HasValue && !orgId.HasValue && !probability.HasValue)
                 {
                     AnsiConsole.MarkupLine("[red]Error:[/] At least one field must be specified to update");
                     return;
@@ -484,6 +490,12 @@ public static class DealsCommands
                 if (!string.IsNullOrWhiteSpace(lostTime) && status == "won")
                 {
                     AnsiConsole.MarkupLine("[red]Error:[/] Cannot use --lost-time with --status won");
+                    return;
+                }
+
+                if (!string.IsNullOrWhiteSpace(lostReason) && status == "won")
+                {
+                    AnsiConsole.MarkupLine("[red]Error:[/] Cannot use --lost-reason with --status won");
                     return;
                 }
 
@@ -503,6 +515,7 @@ public static class DealsCommands
                     deal.ExpectedCloseDate = expectedCloseDate;
                 if (!string.IsNullOrWhiteSpace(wonTime)) deal.WonTime = NormalizeDateTimeFormat(wonTime);
                 if (!string.IsNullOrWhiteSpace(lostTime)) deal.LostTime = NormalizeDateTimeFormat(lostTime);
+                if (!string.IsNullOrWhiteSpace(lostReason)) deal.LostReason = lostReason;
                 if (personId.HasValue) deal.PersonId = personId;
                 if (orgId.HasValue) deal.OrgId = orgId;
                 if (probability.HasValue) deal.Probability = probability;

--- a/src/PipedriveCLI/Models/ApiModels.cs
+++ b/src/PipedriveCLI/Models/ApiModels.cs
@@ -493,6 +493,9 @@ public sealed class Deal
     [JsonPropertyName("lost_time")]
     public string? LostTime { get; set; }
 
+    [JsonPropertyName("lost_reason")]
+    public string? LostReason { get; set; }
+
     [JsonPropertyName("expected_close_date")]
     public string? ExpectedCloseDate { get; set; }
 


### PR DESCRIPTION
## Summary

Closes #136

When marking a deal as lost via `pipedrive deals update <id> --status lost`, users can now specify the reason with `--lost-reason "reason text"`.

**Changes:**
- Add `LostReason` property to Deal model with `lost_reason` JSON mapping
- Add `--lost-reason` option to deals update command
- Validate that `--lost-reason` cannot be used with `--status won`
- Add unit tests for lost_reason serialization/deserialization
- Update README with usage example

## Test plan

- [x] Build succeeds
- [x] All 136 unit tests pass (including 3 new tests for lost_reason)
- [ ] Manual test: `pipedrive deals update <id> --status lost --lost-reason "Customer chose competitor"`
- [ ] Verify `--lost-reason` with `--status won` shows error message