### PR TITLE
Prepare release 0.8.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,40 +7,17 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.8.0</VersionPrefix>
-    <PackageReleaseNotes>This release adds deal product management capabilities and fixes several important filtering and data management bugs.
+    <VersionPrefix>0.8.1</VersionPrefix>
+    <PackageReleaseNotes>This release adds the ability to specify a lost reason when marking deals as lost.
 
 **New Features**
 
-- **Deal Product Management** ([#127](https://github.com/Aaronontheweb/pipedrive-cli/issues/127), [#132](https://github.com/Aaronontheweb/pipedrive-cli/pull/132))
-  - `pipedrive deals products &lt;deal-id&gt;` - List all products attached to a deal
-  - `pipedrive deals add-product &lt;deal-id&gt; --product-id &lt;id&gt; --quantity &lt;n&gt; --price &lt;amount&gt;` - Add a product to a deal
-  - `pipedrive deals remove-product &lt;deal-id&gt; --attachment-id &lt;id&gt;` - Remove a product from a deal
-  - `pipedrive deals clear-products &lt;deal-id&gt;` - Remove all products from a deal
-  - Displays product name, quantity, price, and total value
-  - Enables complete product-based deal management directly from CLI
-  - Example: `pipedrive deals add-product 123 --product-id 456 --quantity 5 --price 99.99`
-
-**Bug Fixes**
-
-- **Fixed Organization Deals Filter** ([#125](https://github.com/Aaronontheweb/pipedrive-cli/issues/125), [#129](https://github.com/Aaronontheweb/pipedrive-cli/pull/129))
-  - Fixed `deals list --org-id` filter returning no results
-  - The `/organizations/{id}/deals` endpoint doesn't support `status=all` like the regular `/deals` endpoint
-  - Now maps "all" to "all_not_deleted" for organization deals endpoint
-  - Ensures consistent behavior across different deal listing methods
-
-- **Filter Archived Lead Activities** ([#126](https://github.com/Aaronontheweb/pipedrive-cli/issues/126), [#131](https://github.com/Aaronontheweb/pipedrive-cli/pull/131))
-  - Activities associated with archived leads are now filtered out by default from `activities list`
-  - Prevents stale/irrelevant activities from cluttering activity list during triage
-  - Added `--include-archived-leads` option (default: false) to show activities for archived leads when needed
-  - Automatically fetches lead details for activities with LeadId to determine archived status
-
-- **Support for Clearing Date Fields** ([#128](https://github.com/Aaronontheweb/pipedrive-cli/issues/128), [#130](https://github.com/Aaronontheweb/pipedrive-cli/pull/130))
-  - Fixed inability to clear date fields on deals
-  - The Pipedrive API requires explicit null values to clear date fields
-  - Added support for `--expected-close-date "clear"` or `--expected-close-date "null"` to remove dates
-  - New UpdateDealAsync overload accepts fields to clear
-  - Example: `pipedrive deals update 123 --expected-close-date clear`
+- **Lost Reason Support for Deals** ([#136](https://github.com/Aaronontheweb/pipedrive-cli/issues/136), [#137](https://github.com/Aaronontheweb/pipedrive-cli/pull/137))
+  - Added `--lost-reason` option to `deals update` command
+  - When marking a deal as lost, users can now specify the reason directly
+  - The lost reason appears in Pipedrive's deal history and reporting
+  - Validates that `--lost-reason` cannot be used with `--status won`
+  - Example: `pipedrive deals update 123 --status lost --lost-reason "Customer chose competitor"`
 
 ---</PackageReleaseNotes>
   </PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,18 @@
+#### 0.8.1 January 21 2026 ####
+
+This release adds the ability to specify a lost reason when marking deals as lost.
+
+**New Features**
+
+- **Lost Reason Support for Deals** ([#136](https://github.com/Aaronontheweb/pipedrive-cli/issues/136), [#137](https://github.com/Aaronontheweb/pipedrive-cli/pull/137))
+  - Added `--lost-reason` option to `deals update` command
+  - When marking a deal as lost, users can now specify the reason directly
+  - The lost reason appears in Pipedrive's deal history and reporting
+  - Validates that `--lost-reason` cannot be used with `--status won`
+  - Example: `pipedrive deals update 123 --status lost --lost-reason "Customer chose competitor"`
+
+---
+
 #### 0.8.0 January 13 2026 ####
 
 This release adds deal product management capabilities and fixes several important filtering and data management bugs.


### PR DESCRIPTION
## Summary

Prepare release 0.8.1 with version bump and release notes.

**Changes in this release:**

- **Lost Reason Support for Deals** ([#136](https://github.com/Aaronontheweb/pipedrive-cli/issues/136), [#137](https://github.com/Aaronontheweb/pipedrive-cli/pull/137))
  - Added `--lost-reason` option to `deals update` command
  - When marking a deal as lost, users can now specify the reason directly
  - Example: `pipedrive deals update 123 --status lost --lost-reason "Customer chose competitor"`

## Test plan

- [x] Version updated in Directory.Build.props
- [x] Release notes added to RELEASE_NOTES.md
- [ ] CI checks pass