### PR TITLE
Add organizationFields command (fixes #141)

### DIFF
--- a/src/PipedriveCLI.Tests/OrganizationsApiClientTests.cs
+++ b/src/PipedriveCLI.Tests/OrganizationsApiClientTests.cs
@@ -317,4 +317,87 @@ public class OrganizationsApiClientTests
         Assert.Null(response.Data.Address);
         Assert.Equal(15, response.Data.PeopleCount);
     }
+
+    /// <summary>
+    /// Test organization field deserialization for organizationFields list command
+    /// </summary>
+    [Fact]
+    public void OrganizationField_Deserialization_HandlesApiResponse()
+    {
+        // Arrange - Organization field definitions from GET /organizationFields
+        var json = """
+        {
+            "success": true,
+            "data": [
+                {
+                    "id": 1,
+                    "key": "name",
+                    "name": "Name",
+                    "field_type": "varchar",
+                    "edit_flag": false,
+                    "mandatory_flag": true
+                },
+                {
+                    "id": 5001,
+                    "key": "8fbeabf7c2b6c7146b504802744f7ca9671853c4",
+                    "name": "Industry",
+                    "field_type": "enum",
+                    "edit_flag": true,
+                    "mandatory_flag": false
+                }
+            ]
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseListOrganizationField);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Equal(2, response.Data.Count);
+
+        // Built-in field
+        var nameField = response.Data[0];
+        Assert.Equal(1, nameField.Id);
+        Assert.Equal("name", nameField.Key);
+        Assert.Equal("Name", nameField.Name);
+        Assert.Equal("varchar", nameField.FieldType);
+        Assert.False(nameField.EditFlag);
+        Assert.True(nameField.MandatoryFlag);
+
+        // Custom field
+        var customField = response.Data[1];
+        Assert.Equal(5001, customField.Id);
+        Assert.Equal("8fbeabf7c2b6c7146b504802744f7ca9671853c4", customField.Key);
+        Assert.Equal("Industry", customField.Name);
+        Assert.Equal("enum", customField.FieldType);
+        Assert.True(customField.EditFlag);
+        Assert.False(customField.MandatoryFlag);
+    }
+
+    /// <summary>
+    /// Test organization field deserialization handles empty result
+    /// </summary>
+    [Fact]
+    public void OrganizationField_Deserialization_HandlesEmptyList()
+    {
+        // Arrange
+        var json = """
+        {
+            "success": true,
+            "data": []
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseListOrganizationField);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Empty(response.Data);
+    }
 }

--- a/src/PipedriveCLI/Commands/OrganizationFieldsCommands.cs
+++ b/src/PipedriveCLI/Commands/OrganizationFieldsCommands.cs
@@ -1,0 +1,127 @@
+using System.CommandLine;
+using PipedriveCLI.Services;
+using Spectre.Console;
+
+namespace PipedriveCLI.Commands;
+
+/// <summary>
+/// Commands for managing Pipedrive organization field definitions
+/// </summary>
+public static class OrganizationFieldsCommands
+{
+    /// <summary>
+    /// Creates the root 'organizationFields' command with all subcommands
+    /// </summary>
+    public static Command CreateOrganizationFieldsCommand(PipedriveApiClient apiClient)
+    {
+        var organizationFieldsCommand = new Command("organizationFields", "Manage Pipedrive organization field definitions (discover custom field keys)");
+
+        // Add subcommands
+        organizationFieldsCommand.AddCommand(CreateListCommand(apiClient));
+
+        return organizationFieldsCommand;
+    }
+
+    /// <summary>
+    /// Creates the 'organizationFields list' command
+    /// </summary>
+    private static Command CreateListCommand(PipedriveApiClient apiClient)
+    {
+        var listCommand = new Command("list", "List all organization fields (including custom fields with their keys)");
+
+        var searchOption = new Option<string?>(
+            aliases: new[] { "--search", "-s" },
+            description: "Filter fields by name (case-insensitive)");
+
+        var customOnlyOption = new Option<bool>(
+            aliases: new[] { "--custom-only", "-c" },
+            description: "Only show custom fields (excludes built-in fields)");
+
+        listCommand.AddOption(searchOption);
+        listCommand.AddOption(customOnlyOption);
+
+        listCommand.SetHandler(async (search, customOnly) =>
+        {
+            try
+            {
+                await apiClient.InitializeAsync();
+
+                await AnsiConsole.Status()
+                    .StartAsync("Fetching organization fields...", async ctx =>
+                    {
+                        ctx.Spinner(Spinner.Known.Dots);
+                        ctx.SpinnerStyle(Style.Parse("green"));
+
+                        var response = await apiClient.GetOrganizationFieldsAsync();
+
+                        if (response?.Success == true && response.Data != null)
+                        {
+                            ctx.Status("Formatting results...");
+
+                            var fields = response.Data.AsEnumerable();
+
+                            // Filter by custom only if requested
+                            if (customOnly)
+                            {
+                                fields = fields.Where(f => f.EditFlag == true);
+                            }
+
+                            // Filter by search term if provided
+                            if (!string.IsNullOrWhiteSpace(search))
+                            {
+                                fields = fields.Where(f =>
+                                    f.Name?.Contains(search, StringComparison.OrdinalIgnoreCase) == true);
+                            }
+
+                            var fieldList = fields.ToList();
+
+                            if (fieldList.Count == 0)
+                            {
+                                AnsiConsole.MarkupLine("[yellow]No matching fields found[/]");
+                            }
+                            else
+                            {
+                                var table = new Table();
+                                table.Border(TableBorder.Rounded);
+                                table.AddColumn(new TableColumn("ID").NoWrap());
+                                table.AddColumn("Key");
+                                table.AddColumn("Name");
+                                table.AddColumn("Type");
+                                table.AddColumn("Editable");
+                                table.AddColumn("Required");
+
+                                foreach (var field in fieldList)
+                                {
+                                    table.AddRow(
+                                        field.Id?.ToString() ?? "-",
+                                        Markup.Escape(field.Key ?? "-"),
+                                        Markup.Escape(field.Name ?? "-"),
+                                        Markup.Escape(field.FieldType ?? "-"),
+                                        field.EditFlag == true ? "[green]Yes[/]" : "[dim]No[/]",
+                                        field.MandatoryFlag == true ? "[yellow]Yes[/]" : "[dim]No[/]"
+                                    );
+                                }
+
+                                AnsiConsole.Write(table);
+
+                                // Show hint about using keys for custom fields
+                                AnsiConsole.MarkupLine($"\n[green]✓[/] Found {fieldList.Count} field(s)");
+                                AnsiConsole.MarkupLine("[dim]Use the 'Key' value with --custom-fields when updating organizations, e.g.:[/]");
+                                AnsiConsole.MarkupLine("[dim]  pipedrive organizations update <id> --custom-fields \"<key>=<value>\"[/]");
+                            }
+                        }
+                        else
+                        {
+                            AnsiConsole.MarkupLine($"[red]✗[/] Failed to fetch organization fields: {Markup.Escape(response?.Error ?? "Unknown error")}");
+                        }
+                    });
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
+            }
+        }, searchOption, customOnlyOption);
+
+        return listCommand;
+    }
+}

--- a/src/PipedriveCLI/Program.cs
+++ b/src/PipedriveCLI/Program.cs
@@ -62,6 +62,9 @@ public static class Program
         // Add deal fields command
         rootCommand.AddCommand(DealFieldsCommands.CreateDealFieldsCommand(apiClient));
 
+        // Add organization fields command
+        rootCommand.AddCommand(OrganizationFieldsCommands.CreateOrganizationFieldsCommand(apiClient));
+
         // Add email templates command
         rootCommand.AddCommand(TemplatesCommands.CreateTemplatesCommand(apiClient));
 


### PR DESCRIPTION
## Summary

- Adds a new `organizationFields` command to list organization field definitions
- Allows users to discover custom field keys and their friendly names
- Mirrors the existing `dealFields` command functionality

**Usage:**
```bash
pipedrive organizationFields list
pipedrive organizationFields list --custom-only
pipedrive organizationFields list --search "Industry"
```

## Test plan

- [x] Build succeeds
- [x] Unit tests pass (added 2 new tests for OrganizationField deserialization)
- [ ] Manual testing with live Pipedrive API

Fixes #141