### PR TITLE
Add leads convert command (fixes #140)

### DIFF
--- a/src/PipedriveCLI.Tests/LeadsCommandTests.cs
+++ b/src/PipedriveCLI.Tests/LeadsCommandTests.cs
@@ -579,4 +579,102 @@ public class LeadsApiClientTests
             Assert.True(Guid.TryParse(leadId, out _), $"Lead {i + 1} ID should be valid UUID: {leadId}");
         }
     }
+
+    /// <summary>
+    /// Test lead convert request serialization
+    /// </summary>
+    [Fact]
+    public void LeadConvertRequest_Serialization_WithStageId()
+    {
+        // Arrange
+        var request = new LeadConvertRequest
+        {
+            StageId = 5,
+            PipelineId = null
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(request, ApiJsonContext.Default.LeadConvertRequest);
+
+        // Assert
+        Assert.Contains("stage_id", json);
+        Assert.Contains("5", json);
+        // PipelineId should not be included when null (due to JsonIgnoreCondition.WhenWritingDefault)
+        Assert.DoesNotContain("pipeline_id", json);
+    }
+
+    /// <summary>
+    /// Test lead convert request serialization with pipeline_id
+    /// </summary>
+    [Fact]
+    public void LeadConvertRequest_Serialization_WithPipelineId()
+    {
+        // Arrange
+        var request = new LeadConvertRequest
+        {
+            StageId = null,
+            PipelineId = 1
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(request, ApiJsonContext.Default.LeadConvertRequest);
+
+        // Assert
+        Assert.Contains("pipeline_id", json);
+        Assert.Contains("1", json);
+        Assert.DoesNotContain("stage_id", json);
+    }
+
+    /// <summary>
+    /// Test lead convert result deserialization
+    /// </summary>
+    [Fact]
+    public void LeadConvertResult_Deserialization_HandlesApiResponse()
+    {
+        // Arrange - Response from POST /leads/{id}/convert/deal
+        var json = """
+        {
+            "success": true,
+            "data": {
+                "conversion_id": "4b40248b-945a-4802-b996-60fdff8c5c69"
+            },
+            "additional_data": null
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseLeadConvertResult);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Equal("4b40248b-945a-4802-b996-60fdff8c5c69", response.Data.ConversionId);
+    }
+
+    /// <summary>
+    /// Test lead convert error response deserialization
+    /// </summary>
+    [Fact]
+    public void LeadConvertResult_Deserialization_HandlesErrorResponse()
+    {
+        // Arrange - Error response when lead not found
+        var json = """
+        {
+            "success": false,
+            "error": "Lead not found",
+            "error_info": "No lead found with ID: invalid-id",
+            "data": null
+        }
+        """;
+
+        // Act
+        var response = JsonSerializer.Deserialize(json, ApiJsonContext.Default.PipedriveResponseLeadConvertResult);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.False(response.Success);
+        Assert.Equal("Lead not found", response.Error);
+        Assert.Null(response.Data);
+    }
 }

--- a/src/PipedriveCLI/Commands/LeadsCommands.cs
+++ b/src/PipedriveCLI/Commands/LeadsCommands.cs
@@ -26,6 +26,7 @@ public static class LeadsCommands
         leadsCommand.AddCommand(CreateSearchCommand(apiClient));
         leadsCommand.AddCommand(CreateArchiveCommand(apiClient));
         leadsCommand.AddCommand(CreateUnarchiveCommand(apiClient));
+        leadsCommand.AddCommand(CreateConvertCommand(apiClient));
 
         return leadsCommand;
     }
@@ -614,5 +615,66 @@ public static class LeadsCommands
         }, idArgument);
 
         return unarchiveCommand;
+    }
+
+    /// <summary>
+    /// Creates the 'leads convert' command
+    /// </summary>
+    private static Command CreateConvertCommand(PipedriveApiClient apiClient)
+    {
+        var convertCommand = new Command("convert", "Convert a lead to a deal");
+
+        var idArgument = new Argument<string>("id", "Lead ID");
+        convertCommand.AddArgument(idArgument);
+
+        var stageIdOption = new Option<int?>(
+            aliases: new[] { "--stage-id", "-s" },
+            description: "Target stage ID for the new deal (determines pipeline automatically)");
+
+        var pipelineIdOption = new Option<int?>(
+            aliases: new[] { "--pipeline-id", "-p" },
+            description: "Target pipeline ID for the new deal (ignored if stage-id is provided)");
+
+        convertCommand.AddOption(stageIdOption);
+        convertCommand.AddOption(pipelineIdOption);
+
+        convertCommand.SetHandler(async (id, stageId, pipelineId) =>
+        {
+            try
+            {
+                await apiClient.InitializeAsync();
+
+                var request = new LeadConvertRequest
+                {
+                    StageId = stageId,
+                    PipelineId = pipelineId
+                };
+
+                var response = await AnsiConsole.Status()
+                    .StartAsync($"Converting lead {id} to deal...", async ctx =>
+                    {
+                        ctx.Spinner(Spinner.Known.Dots);
+                        ctx.SpinnerStyle(Style.Parse("green"));
+                        return await apiClient.ConvertLeadToDealAsync(id, request);
+                    });
+
+                if (response?.Success == true && response.Data != null)
+                {
+                    AnsiConsole.MarkupLine($"[green]✓[/] Lead converted successfully");
+                    AnsiConsole.MarkupLine($"[dim]Conversion ID:[/] {Markup.Escape(response.Data.ConversionId ?? "-")}");
+                    AnsiConsole.MarkupLine("[dim]Note: Conversion runs asynchronously. The deal will appear shortly in Pipedrive.[/]");
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine($"[red]✗[/] Failed to convert lead: {Markup.Escape(response?.Error ?? "Unknown error")}");
+                }
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
+            }
+        }, idArgument, stageIdOption, pipelineIdOption);
+
+        return convertCommand;
     }
 }

--- a/src/PipedriveCLI/Models/ApiModels.cs
+++ b/src/PipedriveCLI/Models/ApiModels.cs
@@ -1403,6 +1403,38 @@ public sealed class AddDealProductRequest
 }
 
 /// <summary>
+/// Request model for converting a lead to a deal via POST /leads/{id}/convert/deal
+/// </summary>
+public sealed class LeadConvertRequest
+{
+    /// <summary>
+    /// The ID of a stage the created deal will be added to.
+    /// If omitted, the deal will be placed in the first stage of the default pipeline.
+    /// </summary>
+    [JsonPropertyName("stage_id")]
+    public int? StageId { get; set; }
+
+    /// <summary>
+    /// The ID of a pipeline the created deal will be added to.
+    /// Note: pipeline_id will be ignored if stage_id is provided.
+    /// </summary>
+    [JsonPropertyName("pipeline_id")]
+    public int? PipelineId { get; set; }
+}
+
+/// <summary>
+/// Response model for lead conversion result
+/// </summary>
+public sealed class LeadConvertResult
+{
+    /// <summary>
+    /// The ID of the conversion job that can be used to retrieve conversion status and details.
+    /// </summary>
+    [JsonPropertyName("conversion_id")]
+    public string? ConversionId { get; set; }
+}
+
+/// <summary>
 /// JSON source generator context for API models (Native AOT compatibility)
 /// </summary>
 [JsonSourceGenerationOptions(
@@ -1413,6 +1445,7 @@ public sealed class AddDealProductRequest
 [JsonSerializable(typeof(PipedriveResponse<Lead>))]
 [JsonSerializable(typeof(PipedriveResponse<List<Lead>>))]
 [JsonSerializable(typeof(PipedriveResponse<LeadSearchData>))]
+[JsonSerializable(typeof(PipedriveResponse<LeadConvertResult>))]
 [JsonSerializable(typeof(PipedriveResponse<OrganizationSearchData>))]
 [JsonSerializable(typeof(PipedriveResponse<PersonSearchData>))]
 [JsonSerializable(typeof(PipedriveResponse<Deal>))]
@@ -1431,6 +1464,8 @@ public sealed class AddDealProductRequest
 [JsonSerializable(typeof(LeadSearchResultLead))]
 [JsonSerializable(typeof(LeadSearchItem))]
 [JsonSerializable(typeof(LeadSearchData))]
+[JsonSerializable(typeof(LeadConvertRequest))]
+[JsonSerializable(typeof(LeadConvertResult))]
 [JsonSerializable(typeof(OrganizationSearchResultOrg))]
 [JsonSerializable(typeof(OrganizationSearchItem))]
 [JsonSerializable(typeof(OrganizationSearchData))]

--- a/src/PipedriveCLI/Services/PipedriveApiClient.cs
+++ b/src/PipedriveCLI/Services/PipedriveApiClient.cs
@@ -242,6 +242,18 @@ public sealed class PipedriveApiClient : IDisposable
     }
 
     /// <summary>
+    /// Converts a lead to a deal
+    /// </summary>
+    /// <param name="id">Lead ID</param>
+    /// <param name="request">Conversion parameters (stage_id, pipeline_id)</param>
+    public async Task<PipedriveResponse<LeadConvertResult>?> ConvertLeadToDealAsync(string id, LeadConvertRequest request)
+    {
+        var jsonData = JsonSerializer.Serialize(request, ApiJsonContext.Default.LeadConvertRequest);
+        var jsonResponse = await PostAsync($"leads/{id}/convert/deal", jsonData);
+        return JsonSerializer.Deserialize(jsonResponse, ApiJsonContext.Default.PipedriveResponseLeadConvertResult);
+    }
+
+    /// <summary>
     /// Searches for leads (uses API v2)
     /// </summary>
     public async Task<PipedriveResponse<List<Lead>>?> SearchLeadsAsync(string term, int? limit = null)


### PR DESCRIPTION
## Summary

- Adds a new `leads convert` command that converts a lead to a deal
- Uses the Pipedrive API endpoint `POST /leads/{id}/convert/deal`
- Conversion runs asynchronously and returns a conversion ID

**Usage:**
```bash
pipedrive leads convert <lead-id>
pipedrive leads convert <lead-id> --stage-id 5
pipedrive leads convert <lead-id> --pipeline-id 1
```

**Options:**
- `--stage-id/-s`: Target stage for the new deal (determines pipeline automatically)
- `--pipeline-id/-p`: Target pipeline for the new deal (ignored if stage-id is provided)

## Test plan

- [x] Build succeeds
- [x] All unit tests pass (added 4 new tests for LeadConvertRequest/Result serialization)
- [ ] Manual testing with live Pipedrive API

Fixes #140