### PR TITLE
Prepare release 0.8.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,17 +7,26 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.8.1</VersionPrefix>
-    <PackageReleaseNotes>This release adds the ability to specify a lost reason when marking deals as lost.
+    <VersionPrefix>0.8.2</VersionPrefix>
+    <PackageReleaseNotes>This release adds the ability to convert leads to deals and discover organization custom field definitions.
 
 **New Features**
 
-- **Lost Reason Support for Deals** ([#136](https://github.com/Aaronontheweb/pipedrive-cli/issues/136), [#137](https://github.com/Aaronontheweb/pipedrive-cli/pull/137))
-  - Added `--lost-reason` option to `deals update` command
-  - When marking a deal as lost, users can now specify the reason directly
-  - The lost reason appears in Pipedrive's deal history and reporting
-  - Validates that `--lost-reason` cannot be used with `--status won`
-  - Example: `pipedrive deals update 123 --status lost --lost-reason "Customer chose competitor"`
+- **Lead Conversion** ([#140](https://github.com/Aaronontheweb/pipedrive-cli/issues/140), [#143](https://github.com/Aaronontheweb/pipedrive-cli/pull/143))
+  - Added `pipedrive leads convert &lt;lead-id&gt;` command to convert a lead to a deal
+  - Uses Pipedrive's async conversion API to preserve lead history and create a properly linked deal
+  - Supports `--stage-id` option to specify target stage (automatically determines pipeline)
+  - Supports `--pipeline-id` option to specify target pipeline (ignored if stage-id is provided)
+  - Eliminates the need to manually create deals and lose audit trail
+  - Example: `pipedrive leads convert abc123 --stage-id 5`
+
+- **Organization Fields Discovery** ([#141](https://github.com/Aaronontheweb/pipedrive-cli/issues/141), [#142](https://github.com/Aaronontheweb/pipedrive-cli/pull/142))
+  - Added `pipedrive organizationFields list` command to discover organization field definitions
+  - Displays custom field keys and their human-readable names
+  - Supports `--custom-only` option to show only custom fields
+  - Supports `--search` option to filter fields by name
+  - Essential for identifying hash keys when updating organization custom fields
+  - Example: `pipedrive organizationFields list --custom-only`
 
 ---</PackageReleaseNotes>
   </PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,27 @@
+#### 0.8.2 January 26 2026 ####
+
+This release adds the ability to convert leads to deals and discover organization custom field definitions.
+
+**New Features**
+
+- **Lead Conversion** ([#140](https://github.com/Aaronontheweb/pipedrive-cli/issues/140), [#143](https://github.com/Aaronontheweb/pipedrive-cli/pull/143))
+  - Added `pipedrive leads convert <lead-id>` command to convert a lead to a deal
+  - Uses Pipedrive's async conversion API to preserve lead history and create a properly linked deal
+  - Supports `--stage-id` option to specify target stage (automatically determines pipeline)
+  - Supports `--pipeline-id` option to specify target pipeline (ignored if stage-id is provided)
+  - Eliminates the need to manually create deals and lose audit trail
+  - Example: `pipedrive leads convert abc123 --stage-id 5`
+
+- **Organization Fields Discovery** ([#141](https://github.com/Aaronontheweb/pipedrive-cli/issues/141), [#142](https://github.com/Aaronontheweb/pipedrive-cli/pull/142))
+  - Added `pipedrive organizationFields list` command to discover organization field definitions
+  - Displays custom field keys and their human-readable names
+  - Supports `--custom-only` option to show only custom fields
+  - Supports `--search` option to filter fields by name
+  - Essential for identifying hash keys when updating organization custom fields
+  - Example: `pipedrive organizationFields list --custom-only`
+
+---
+
 #### 0.8.1 January 21 2026 ####
 
 This release adds the ability to specify a lost reason when marking deals as lost.


### PR DESCRIPTION
## Release 0.8.2

### New Features
- Add `organizationFields` command to list organization field definitions (#141)
- Add `leads convert` command to convert leads to deals (#140)

### Changes
- `organizationFields list` - List all organization fields including custom fields with their keys
  - Supports `--search` and `--custom-only` options
- `leads convert <id>` - Convert a lead to a deal
  - Supports `--stage-id` and `--pipeline-id` options
  - Conversion runs asynchronously via Pipedrive API

This PR updates the release notes and version for release 0.8.2.