### PR TITLE
Fix release workflow version prefix stripping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,8 @@ jobs:
           else
             VERSION=${GITHUB_REF#refs/tags/}
           fi
+          # Strip leading 'v' prefix if present (e.g., v0.8.2 -> 0.8.2)
+          VERSION=${VERSION#v}
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
           # Extract numeric version for AssemblyVersion (e.g., 1.0.0 from 1.0.0-beta1)
@@ -155,6 +157,8 @@ jobs:
       - name: "Extract version"
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
+          # Strip leading 'v' prefix if present (e.g., v0.8.2 -> 0.8.2)
+          VERSION=${VERSION#v}
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: "Generate release notes"


### PR DESCRIPTION
## Summary

Fixes the release workflow that was failing because it used the tag name (e.g., `v0.8.2`) directly as the .NET version, but .NET requires numeric versions without the `v` prefix.

**Error:**
```
'v0.8.2' is not a valid version string. (Parameter 'value')
```

**Fix:**
Strips the leading `v` prefix from tags before using as version number.

## Test plan

- [ ] Merge this PR
- [ ] Delete and re-push the v0.8.2 tag to trigger a new release build