### PR TITLE
Reject v-prefixed release tags in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,25 @@ on:
         type: string
 
 jobs:
+  validate-tag:
+    name: Validate Tag
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: "Reject v-prefixed tags"
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          if [[ "$TAG" == v* ]]; then
+            echo "ERROR: Tag '$TAG' starts with 'v'. Use bare version tags (e.g., '0.9.0' not 'v0.9.0')."
+            exit 1
+          fi
+          echo "Tag '$TAG' is valid."
+
   build-binaries:
     name: Build-${{matrix.runtime}}
     runs-on: ${{matrix.os}}
+    needs: [validate-tag]
+    if: always() && (needs.validate-tag.result == 'success' || github.event_name == 'workflow_dispatch')
 
     strategy:
       fail-fast: false
@@ -134,9 +150,9 @@ jobs:
 
   create-release:
     name: Create Release
-    needs: build-binaries
+    needs: [validate-tag, build-binaries]
     runs-on: ubuntu-latest
-    if: always() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    if: always() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && needs.validate-tag.result == 'success'
 
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Adds a `validate-tag` job to the release workflow that fails fast if a tag has a `v` prefix (e.g. `v0.9.0`)
- `build-binaries` and `create-release` now depend on `validate-tag` and won't run if it fails
- `workflow_dispatch` is unaffected — the validation only runs on tag push events

## Background

The `v0.8.2` tag was accidentally created with a `v` prefix. The install scripts assume bare version tags (e.g. `0.8.2`) and construct download URLs accordingly. A `v`-prefixed tag causes the installer to request a filename like `pipedrive-v0.8.2-linux-x64.tar.gz`, which doesn't exist — GitHub serves an HTML 404 page, and `tar` then fails with "not in gzip format".

## After merge

The `v0.8.2` release and tag will be deleted and recreated as `0.8.2` to fix the live installer.